### PR TITLE
[FEATURE&TEST] FCM 토큰을 저장하는 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 
 	// s3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	//fcm
+	implementation 'com.google.firebase:firebase-admin:9.1.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/TImeCAlling/spring/domain/User.java
+++ b/src/main/java/TImeCAlling/spring/domain/User.java
@@ -90,4 +90,9 @@ public class User extends BaseEntity implements UserDetails {
             failed += 1;
         }
     }
+
+    /**Fcm 토큰 업데이트 관련 메소드*/
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
 }

--- a/src/main/java/TImeCAlling/spring/service/pushMessageNotification/PushNotificationCommandService.java
+++ b/src/main/java/TImeCAlling/spring/service/pushMessageNotification/PushNotificationCommandService.java
@@ -1,0 +1,9 @@
+package TImeCAlling.spring.service.pushMessageNotification;
+
+import TImeCAlling.spring.domain.User;
+import TImeCAlling.spring.web.dto.fcm.FcmTokenResponseDTO;
+
+public interface PushNotificationCommandService {
+
+    FcmTokenResponseDTO.UpdateDTO updateFcmToken(User user, String fcmToken);
+}

--- a/src/main/java/TImeCAlling/spring/service/pushMessageNotification/PushNotificationCommandServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/pushMessageNotification/PushNotificationCommandServiceImpl.java
@@ -1,0 +1,27 @@
+package TImeCAlling.spring.service.pushMessageNotification;
+
+import TImeCAlling.spring.domain.User;
+import TImeCAlling.spring.repository.user.UserRepository;
+import TImeCAlling.spring.web.dto.fcm.FcmTokenResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PushNotificationCommandServiceImpl implements PushNotificationCommandService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public FcmTokenResponseDTO.UpdateDTO updateFcmToken(User user, String fcmToken) {
+
+        user.updateFcmToken(fcmToken);
+        userRepository.save(user);
+
+        return FcmTokenResponseDTO.UpdateDTO.builder()
+                .userId(user.getId())
+                .build();
+    }
+}

--- a/src/main/java/TImeCAlling/spring/web/controller/pushMessageNotification/PushMessageNotificationController.java
+++ b/src/main/java/TImeCAlling/spring/web/controller/pushMessageNotification/PushMessageNotificationController.java
@@ -1,0 +1,31 @@
+package TImeCAlling.spring.web.controller.pushMessageNotification;
+
+import TImeCAlling.spring.apiPayload.ApiResponse;
+import TImeCAlling.spring.domain.User;
+import TImeCAlling.spring.service.pushMessageNotification.PushNotificationCommandService;
+import TImeCAlling.spring.service.user.UserQueryService;
+import TImeCAlling.spring.web.dto.fcm.FcmTokenRequestDTO;
+import TImeCAlling.spring.web.dto.fcm.FcmTokenResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/push-requests")
+public class PushMessageNotificationController {
+
+    private final PushNotificationCommandService pushNotificationCommandService;
+    private final UserQueryService userQueryService;
+
+    @PatchMapping("/fcm-token")
+    public ApiResponse<FcmTokenResponseDTO.UpdateDTO> updateFcmToken(
+            @RequestBody FcmTokenRequestDTO.UpdateDTO updateDTO) {
+
+        User findUser = userQueryService.findOne(updateDTO.getUserId());
+
+        return ApiResponse.onSuccess(pushNotificationCommandService.updateFcmToken(findUser, updateDTO.getFcmToken()));
+    }
+}

--- a/src/main/java/TImeCAlling/spring/web/controller/pushMessageNotification/PushMessageNotificationController.java
+++ b/src/main/java/TImeCAlling/spring/web/controller/pushMessageNotification/PushMessageNotificationController.java
@@ -1,7 +1,6 @@
 package TImeCAlling.spring.web.controller.pushMessageNotification;
 
 import TImeCAlling.spring.apiPayload.ApiResponse;
-import TImeCAlling.spring.domain.User;
 import TImeCAlling.spring.service.pushMessageNotification.PushNotificationCommandService;
 import TImeCAlling.spring.service.user.UserQueryService;
 import TImeCAlling.spring.web.dto.fcm.FcmTokenRequestDTO;
@@ -24,8 +23,7 @@ public class PushMessageNotificationController {
     public ApiResponse<FcmTokenResponseDTO.UpdateDTO> updateFcmToken(
             @RequestBody FcmTokenRequestDTO.UpdateDTO updateDTO) {
 
-        User findUser = userQueryService.findOne(updateDTO.getUserId());
-
-        return ApiResponse.onSuccess(pushNotificationCommandService.updateFcmToken(findUser, updateDTO.getFcmToken()));
+        return ApiResponse.onSuccess(pushNotificationCommandService.updateFcmToken(
+                userQueryService.findOne(updateDTO.getUserId()), updateDTO.getFcmToken()));
     }
 }

--- a/src/main/java/TImeCAlling/spring/web/dto/fcm/FcmTokenRequestDTO.java
+++ b/src/main/java/TImeCAlling/spring/web/dto/fcm/FcmTokenRequestDTO.java
@@ -1,0 +1,14 @@
+package TImeCAlling.spring.web.dto.fcm;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class FcmTokenRequestDTO {
+
+    @Builder
+    @Getter
+    public static class UpdateDTO {
+        private Long userId;
+        private String fcmToken;
+    }
+}

--- a/src/main/java/TImeCAlling/spring/web/dto/fcm/FcmTokenResponseDTO.java
+++ b/src/main/java/TImeCAlling/spring/web/dto/fcm/FcmTokenResponseDTO.java
@@ -1,0 +1,17 @@
+package TImeCAlling.spring.web.dto.fcm;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class FcmTokenResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateDTO {
+        private Long userId;
+    }
+}

--- a/src/test/java/TImeCAlling/spring/service/pushNotification/PushNotificationCommandServiceTest.java
+++ b/src/test/java/TImeCAlling/spring/service/pushNotification/PushNotificationCommandServiceTest.java
@@ -1,0 +1,54 @@
+package TImeCAlling.spring.service.pushNotification;
+
+import TImeCAlling.spring.domain.User;
+import TImeCAlling.spring.repository.user.UserRepository;
+import TImeCAlling.spring.service.pushMessageNotification.PushNotificationCommandServiceImpl;
+import TImeCAlling.spring.web.dto.fcm.FcmTokenResponseDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PushNotificationCommandServiceTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private PushNotificationCommandServiceImpl pushNotificationCommandService;
+
+    @Test
+    @DisplayName("fcm 토큰 업데이트 정상작동")
+    void updateFcmTokenSuccess() {
+        // Given
+        Long userId = 1L;
+        String oldFcmToken = "oldFcmToken";
+        String newFcmToken = "newFcmToken";
+
+        User user = User.builder()
+                .id(userId)
+                .fcmToken(oldFcmToken)
+                .build();
+
+
+        when(userRepository.save(any(User.class))).thenReturn(user);
+
+        // When
+        FcmTokenResponseDTO.UpdateDTO response =
+                pushNotificationCommandService.updateFcmToken(user, newFcmToken);
+
+        // Then
+        //FCM 토큰이 정상적으로 반영되었는지 검증
+        assertNotNull(response);
+        assertEquals(userId, response.getUserId());
+        assertEquals(newFcmToken, user.getFcmToken());
+
+        //메서드 호출 횟수 검증
+        verify(userRepository, times(1)).save(user);
+    }
+}


### PR DESCRIPTION
## Issue

- #39 


## Summary

- FCM 토큰을 프론트에서 넘기면 해당 토큰을 user 엔티티에 있는 fcmToken 칼럼에 새로 저장 또는 업데이트를 하는 API입니다.
- Response 값으론 해당 fcmToken의 소유주의 userId를 반환합니다.

## Describe your code

- user 도메인에 fcmToken 저장을 위한 메소드가 추가되었습니다.

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
