### PR TITLE
[REFACTOR] 일정 상세 조회 시 checklistId 사용

### DIFF
--- a/src/main/java/TImeCAlling/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TImeCAlling/spring/apiPayload/code/status/ErrorStatus.java
@@ -47,6 +47,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EXTERNAL_NOT_FOUND(HttpStatus.NOT_FOUND, "CHECKLIST4002", "해당 값을 찾을 수 없습니다."),
     LATE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHECKLIST4003", "해당 값을 찾을 수 없습니다."),
     REASON_NOT_FOUND(HttpStatus.NOT_FOUND, "CHECKLIST4004", "해당 값을 찾을 수 없습니다."),
+    CHECKLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "CHECKLIST4005", "체크리스트를 찾을 수 없습니다."),
 
     ;
 

--- a/src/main/java/TImeCAlling/spring/converter/schedule/ScheduleConverter.java
+++ b/src/main/java/TImeCAlling/spring/converter/schedule/ScheduleConverter.java
@@ -58,6 +58,7 @@ public class ScheduleConverter {
                     .toList();
             return ScheduleResponseDTO.ScheduleGetDTO.builder()
                     .name(schedule.getName())
+                    .meetDate(schedule.getChecklists().get(0).getDate())
                     .meetTime(schedule.getMeetTime())
                     .place(schedule.getPlace())
                     .repeatDays(repeatDays)
@@ -72,6 +73,7 @@ public class ScheduleConverter {
         } else {
             return ScheduleResponseDTO.ScheduleGetDTO.builder()
                     .name(schedule.getName())
+                    .meetDate(schedule.getChecklists().get(0).getDate())
                     .meetTime(schedule.getMeetTime())
                     .place(schedule.getPlace())
                     .repeatDays(null)

--- a/src/main/java/TImeCAlling/spring/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/TImeCAlling/spring/repository/schedule/ScheduleRepository.java
@@ -11,6 +11,9 @@ import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
+    @Query("SELECT s FROM Schedule s JOIN s.checklists c WHERE c.id = :checklistId AND s.user = :user")
+    Optional<Schedule> findByChecklistIdAndUser(@Param("checklistId") Long checklistId, @Param("user") User user);
+
     @Query("SELECT s FROM Schedule s JOIN FETCH s.categories WHERE s.id = :id")
     Optional<Schedule> findByIdWithCategories(@Param("id") Long id);
 

--- a/src/main/java/TImeCAlling/spring/service/schedule/ScheduleQueryService.java
+++ b/src/main/java/TImeCAlling/spring/service/schedule/ScheduleQueryService.java
@@ -7,6 +7,7 @@ import TImeCAlling.spring.web.dto.schedule.ScheduleResponseDTO;
 import java.util.List;
 
 public interface ScheduleQueryService {
+    public Schedule getScheduleWithChecklist(Long checklistId, User user);
     public Schedule getSchedule(Long scheduleId, User user);
     public Schedule getSchedule(Long scheduleId);
     public List<ScheduleResponseDTO.SharedScheduleUserDTO> getSharedScheduleUsers(Schedule schedule);

--- a/src/main/java/TImeCAlling/spring/service/schedule/ScheduleQueryServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/schedule/ScheduleQueryServiceImpl.java
@@ -21,6 +21,12 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
     private final ScheduleRepository scheduleRepository;
 
     @Override
+    public Schedule getScheduleWithChecklist(Long checklistId, User user) {
+
+        return scheduleRepository.findByChecklistIdAndUser(checklistId, user).orElseThrow(() -> new ScheduleHandler(ErrorStatus._BAD_REQUEST));
+    }
+
+    @Override
     @ExistSchedule
     public Schedule getSchedule(Long scheduleId, User user) {
         

--- a/src/main/java/TImeCAlling/spring/validation/annotation/ExistChecklist.java
+++ b/src/main/java/TImeCAlling/spring/validation/annotation/ExistChecklist.java
@@ -1,0 +1,18 @@
+package TImeCAlling.spring.validation.annotation;
+
+import TImeCAlling.spring.validation.validator.ExistChecklistValidator;
+import TImeCAlling.spring.validation.validator.ExistScheduleValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Constraint(validatedBy = ExistChecklistValidator.class)
+public @interface ExistChecklist {
+    String message() default "해당하는 체크리스트가 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/TImeCAlling/spring/validation/validator/ExistChecklistValidator.java
+++ b/src/main/java/TImeCAlling/spring/validation/validator/ExistChecklistValidator.java
@@ -1,0 +1,31 @@
+package TImeCAlling.spring.validation.validator;
+
+import TImeCAlling.spring.apiPayload.code.status.ErrorStatus;
+import TImeCAlling.spring.repository.schedule.ChecklistRepository;
+import TImeCAlling.spring.validation.annotation.ExistChecklist;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ExistChecklistValidator implements ConstraintValidator<ExistChecklist, Long> {
+    private final ChecklistRepository checklistRepository;
+
+    @Override
+    public void initialize(ExistChecklist constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        boolean result = checklistRepository.existsById(value);
+        if (!result) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.CHECKLIST_NOT_FOUND.toString()).addConstraintViolation();
+        }
+        return result;
+    }
+}
+

--- a/src/main/java/TImeCAlling/spring/web/controller/schedule/ScheduleController.java
+++ b/src/main/java/TImeCAlling/spring/web/controller/schedule/ScheduleController.java
@@ -12,6 +12,7 @@ import TImeCAlling.spring.service.schedule.ScheduleCommandService;
 import TImeCAlling.spring.service.schedule.ScheduleQueryService;
 import TImeCAlling.spring.service.schedule.checklist.ChecklistQueryService;
 import TImeCAlling.spring.service.user.UserQueryService;
+import TImeCAlling.spring.validation.annotation.ExistChecklist;
 import TImeCAlling.spring.validation.annotation.ExistSchedule;
 import TImeCAlling.spring.web.dto.schedule.ScheduleRequestDTO;
 import TImeCAlling.spring.web.dto.schedule.ScheduleResponseDTO;
@@ -57,10 +58,10 @@ public class ScheduleController {
     }
 
     @Operation(summary = "일정 상세 조회", description = "일정 id로 일정의 정보를 상세 조회합니다.")
-    @GetMapping("/{scheduleId}")
-    public ApiResponse<ScheduleResponseDTO.ScheduleGetDTO> scheduleGet(@AuthenticationPrincipal User user, @PathVariable @ExistSchedule Long scheduleId) {
+    @GetMapping("/{checklistId}")
+    public ApiResponse<ScheduleResponseDTO.ScheduleGetDTO> scheduleGet(@AuthenticationPrincipal User user, @PathVariable @ExistChecklist Long checklistId) {
 
-        Schedule schedule = scheduleQueryService.getSchedule(scheduleId, user);
+        Schedule schedule = scheduleQueryService.getScheduleWithChecklist(checklistId, user);
         return ApiResponse.onSuccess(ScheduleConverter.toScheduleGetDTO(schedule, schedule.getRecurringSchedule() == null ? null : schedule.getRecurringSchedule()));
     }
 

--- a/src/main/java/TImeCAlling/spring/web/controller/schedule/ScheduleController.java
+++ b/src/main/java/TImeCAlling/spring/web/controller/schedule/ScheduleController.java
@@ -44,7 +44,7 @@ public class ScheduleController {
 
     private final ChecklistCommandService checklistService;
 
-    @Operation(summary = "일정 추가", description = "새로운 일정을 추가합니다.")
+    @Operation(summary = "일정 추가", description = "새로운 일정을 추가합니다. meetTime에 HH:mm 형식만 입력 가능합니다!")
     @PostMapping
     public ApiResponse<ScheduleResponseDTO.ScheduleCreateDTO> scheduleCreate(@AuthenticationPrincipal User user, @RequestBody @Valid ScheduleRequestDTO.ScheduleCreateDTO request) {
 
@@ -57,7 +57,7 @@ public class ScheduleController {
         return ApiResponse.onSuccess(ScheduleConverter.toScheduleCreateDTO(schedule));
     }
 
-    @Operation(summary = "일정 상세 조회", description = "일정 id로 일정의 정보를 상세 조회합니다.")
+    @Operation(summary = "일정 상세 조회", description = "체크리스트 id로 일정의 정보를 상세 조회합니다.")
     @GetMapping("/{checklistId}")
     public ApiResponse<ScheduleResponseDTO.ScheduleGetDTO> scheduleGet(@AuthenticationPrincipal User user, @PathVariable @ExistChecklist Long checklistId) {
 
@@ -65,7 +65,7 @@ public class ScheduleController {
         return ApiResponse.onSuccess(ScheduleConverter.toScheduleGetDTO(schedule, schedule.getRecurringSchedule() == null ? null : schedule.getRecurringSchedule()));
     }
 
-    @Operation(summary = "일정 수정", description = "일정 id로 일정의 정보를 수정합니다. 공유하지 않은 일정은 모든 항목에 대해 수정 가능합니다.")
+    @Operation(summary = "일정 수정", description = "일정 id로 일정의 정보를 수정합니다. 공유하지 않은 일정은 모든 항목에 대해 수정 가능합니다. meetTime에 HH:mm 형식만 입력 가능합니다!")
     @PatchMapping("/{scheduleId}")
     public ApiResponse<ScheduleResponseDTO.ScheduleGetDTO> schedulePatch(@AuthenticationPrincipal User user, @PathVariable @ExistSchedule Long scheduleId, @RequestBody @Valid ScheduleRequestDTO.SchedulePatchDTO request) {
 

--- a/src/main/java/TImeCAlling/spring/web/dto/schedule/ScheduleRequestDTO.java
+++ b/src/main/java/TImeCAlling/spring/web/dto/schedule/ScheduleRequestDTO.java
@@ -3,6 +3,7 @@ package TImeCAlling.spring.web.dto.schedule;
 import TImeCAlling.spring.domain.enums.FreeTime;
 import TImeCAlling.spring.domain.enums.RepeatDay;
 import TImeCAlling.spring.validation.annotation.ValidEnum;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -40,7 +41,8 @@ public class ScheduleRequestDTO {
 
         @NotNull
         LocalDate meetDate;
-        
+
+        @JsonFormat(pattern = "HH:mm")
         @NotNull
         LocalTime meetTime;
 
@@ -82,12 +84,13 @@ public class ScheduleRequestDTO {
         
         @Size(max = 20)
         String body;
-        
-        @NotNull
-        LocalTime meetTime;
-        
+
         @NotNull
         LocalDate meetDate;
+
+        @JsonFormat(pattern = "HH:mm")
+        @NotNull
+        LocalTime meetTime;
         
         @NotNull
         String place;

--- a/src/main/java/TImeCAlling/spring/web/dto/schedule/ScheduleResponseDTO.java
+++ b/src/main/java/TImeCAlling/spring/web/dto/schedule/ScheduleResponseDTO.java
@@ -1,5 +1,6 @@
 package TImeCAlling.spring.web.dto.schedule;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,6 +37,8 @@ public class ScheduleResponseDTO {
     public static class ScheduleGetDTO{
         String name;
         LocalDate meetDate;
+
+        @JsonFormat(pattern = "HH:mm")
         LocalTime meetTime;
         String place;
         List<String> repeatDays;

--- a/src/main/java/TImeCAlling/spring/web/dto/schedule/ScheduleResponseDTO.java
+++ b/src/main/java/TImeCAlling/spring/web/dto/schedule/ScheduleResponseDTO.java
@@ -35,6 +35,7 @@ public class ScheduleResponseDTO {
     @AllArgsConstructor
     public static class ScheduleGetDTO{
         String name;
+        LocalDate meetDate;
         LocalTime meetTime;
         String place;
         List<String> repeatDays;


### PR DESCRIPTION
## Issue

- #60 

## Summary

- 일정 상세 정보 조회 시, 기존의 scheduleId 대신 checklistId를 path variable로 사용

## Describe your code

- 코드 설명 (설명이 필요한 코드가 있다고 생각하시면 간단하게 작성해주세요.)

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
