### PR TITLE
[FEATURE] 공유 일정 API 구현

### DIFF
--- a/src/main/java/TImeCAlling/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TImeCAlling/spring/apiPayload/code/status/ErrorStatus.java
@@ -41,6 +41,7 @@ public enum ErrorStatus implements BaseErrorCode {
     SCHEDULE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "SCHEDULE4002", "일정 삭제에 실패했습니다."),
     RECURRING_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE4003", "반복 일정 정보가 정상적으로 저장되지 않았습니다."),
     SCHEDULE_SHARE_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE4004", "일정의 공유 ID를 찾을 수 업습니다."),
+    SCHEDULE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "SCHEDULE4005", "이미 존재하는 공유 일정입니다."),
 
     // 체크리스트 관련 에러
     SPARE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHECKLIST4001", "해당 값을 찾을 수 없습니다."),

--- a/src/main/java/TImeCAlling/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TImeCAlling/spring/apiPayload/code/status/ErrorStatus.java
@@ -41,7 +41,13 @@ public enum ErrorStatus implements BaseErrorCode {
     SCHEDULE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "SCHEDULE4002", "일정 삭제에 실패했습니다."),
     RECURRING_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE4003", "반복 일정 정보가 정상적으로 저장되지 않았습니다."),
     SCHEDULE_SHARE_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE4004", "일정의 공유 ID를 찾을 수 업습니다."),
-    SCHEDULE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "SCHEDULE4005", "이미 존재하는 공유 일정입니다."),
+    SCHEDULE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "SCHEDULE4005", "이미 존재하는 일정입니다."),
+    SCHEDULE_NAME_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE4006", "공유 일정은 이름을 수정할 수 없습니다."),
+    SCHEDULE_DATE_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE4007", "공유 일정은 날짜를 수정할 수 없습니다."),
+    SCHEDULE_TIME_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE4008", "공유 일정은 시간을 수정할 수 없습니다."),
+    SCHEDULE_PLACE_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE4009", "공유 일정은 장소를 수정할 수 없습니다."),
+    SCHEDULE_LONGITUDE_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE4010", "공유 일정은 경도를 수정할 수 없습니다."),
+    SCHEDULE_LATITUDE_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE4011", "공유 일정은 위도를 수정할 수 없습니다."),
 
     // 체크리스트 관련 에러
     SPARE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHECKLIST4001", "해당 값을 찾을 수 없습니다."),

--- a/src/main/java/TImeCAlling/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TImeCAlling/spring/apiPayload/code/status/ErrorStatus.java
@@ -48,6 +48,8 @@ public enum ErrorStatus implements BaseErrorCode {
     SCHEDULE_PLACE_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE4009", "공유 일정은 장소를 수정할 수 없습니다."),
     SCHEDULE_LONGITUDE_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE4010", "공유 일정은 경도를 수정할 수 없습니다."),
     SCHEDULE_LATITUDE_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE4011", "공유 일정은 위도를 수정할 수 없습니다."),
+    REPEAT_DAYS_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE4012", "공유 일정은 반복 요일을 수정할 수 없습니다."),
+    RECURRING_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE4013", "공유 일정은 반복 설정을 수정할 수 없습니다."),
 
     // 체크리스트 관련 에러
     SPARE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHECKLIST4001", "해당 값을 찾을 수 없습니다."),

--- a/src/main/java/TImeCAlling/spring/converter/schedule/ScheduleConverter.java
+++ b/src/main/java/TImeCAlling/spring/converter/schedule/ScheduleConverter.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class ScheduleConverter {
@@ -42,6 +43,7 @@ public class ScheduleConverter {
                 .freeTime(freeTime)
                 .isRepeat(request.getIsRepeat())
                 .categories(categories)
+                .shareId(UUID.randomUUID().toString())
                 .build();
     }
 
@@ -135,7 +137,43 @@ public class ScheduleConverter {
                 .scheduleId(scheduleId)
                 .build();
     }
-    
+
+    public static ScheduleResponseDTO.GetShareScheduleDTO toGetShareScheduleDTO(User user, Schedule schedule, RecurringSchedule recurringSchedule) {
+
+        if (schedule.getIsRepeat()) {
+            List<String> repeatDays = recurringSchedule.getRepeatDays().stream()
+                    .map(Enum::toString)
+                    .toList();
+            return ScheduleResponseDTO.GetShareScheduleDTO.builder()
+                    .nickname(user.getNickname())
+                    .name(schedule.getName())
+                    .meetDate(schedule.getChecklists().get(0).getDate())
+                    .meetTime(schedule.getMeetTime())
+                    .place(schedule.getPlace())
+                    .longitude(schedule.getLongitude())
+                    .latitude(schedule.getLatitude())
+                    .repeatDays(repeatDays)
+                    .isRepeat(schedule.getIsRepeat())
+                    .start(recurringSchedule.getStart())
+                    .end(recurringSchedule.getEnd())
+                    .build();
+        } else {
+            return ScheduleResponseDTO.GetShareScheduleDTO.builder()
+                    .nickname(user.getNickname())
+                    .name(schedule.getName())
+                    .meetDate(schedule.getChecklists().get(0).getDate())
+                    .meetTime(schedule.getMeetTime())
+                    .place(schedule.getPlace())
+                    .longitude(schedule.getLongitude())
+                    .latitude(schedule.getLatitude())
+                    .repeatDays(null)
+                    .isRepeat(schedule.getIsRepeat())
+                    .start(null)
+                    .end(null)
+                    .build();
+        }
+    }
+
     public static ScheduleResponseDTO.ScheduleStatusDTO toScheduleStatusDTO(Schedule schedule) {
         
         Long leftTime = ChronoUnit.MINUTES.between(LocalTime.now(), schedule.getMeetTime());

--- a/src/main/java/TImeCAlling/spring/converter/schedule/ScheduleConverter.java
+++ b/src/main/java/TImeCAlling/spring/converter/schedule/ScheduleConverter.java
@@ -59,6 +59,7 @@ public class ScheduleConverter {
                     .map(Enum::toString)
                     .toList();
             return ScheduleResponseDTO.ScheduleGetDTO.builder()
+                    .scheduleId(schedule.getId())
                     .name(schedule.getName())
                     .meetDate(schedule.getChecklists().get(0).getDate())
                     .meetTime(schedule.getMeetTime())
@@ -75,6 +76,7 @@ public class ScheduleConverter {
                     .build();
         } else {
             return ScheduleResponseDTO.ScheduleGetDTO.builder()
+                    .scheduleId(schedule.getId())
                     .name(schedule.getName())
                     .meetDate(schedule.getChecklists().get(0).getDate())
                     .meetTime(schedule.getMeetTime())

--- a/src/main/java/TImeCAlling/spring/converter/schedule/ScheduleConverter.java
+++ b/src/main/java/TImeCAlling/spring/converter/schedule/ScheduleConverter.java
@@ -16,6 +16,7 @@ public class ScheduleConverter {
     public static ScheduleResponseDTO.ScheduleCreateDTO toScheduleCreateDTO(Schedule schedule) {
         return ScheduleResponseDTO.ScheduleCreateDTO.builder()
                 .scheduleId(schedule.getId())
+                .shareId(schedule.getShareId())
                 .createdAt(LocalDateTime.now())
                 .build();
     }
@@ -43,7 +44,6 @@ public class ScheduleConverter {
                 .freeTime(freeTime)
                 .isRepeat(request.getIsRepeat())
                 .categories(categories)
-                .shareId(UUID.randomUUID().toString())
                 .build();
     }
 
@@ -71,6 +71,7 @@ public class ScheduleConverter {
                     .start(recurringSchedule.getStart())
                     .end(recurringSchedule.getEnd())
                     .categories(categoryDTOS)
+                    .shareId(schedule.getShareId())
                     .build();
         } else {
             return ScheduleResponseDTO.ScheduleGetDTO.builder()
@@ -86,6 +87,7 @@ public class ScheduleConverter {
                     .start(null)
                     .end(null)
                     .categories(categoryDTOS)
+                    .shareId(schedule.getShareId())
                     .build();
         }
     }
@@ -114,6 +116,7 @@ public class ScheduleConverter {
                     .start(schedule.getRecurringSchedule().getStart())
                     .end(schedule.getRecurringSchedule().getEnd())
                     .categories(categoryDTOS)
+                    .shareId(schedule.getShareId())
                     .build();
         } else {
             return ScheduleResponseDTO.ScheduleGetDTO.builder()
@@ -128,6 +131,7 @@ public class ScheduleConverter {
                     .start(null)
                     .end(null)
                     .categories(categoryDTOS)
+                    .shareId(schedule.getShareId())
                     .build();
         }
     }
@@ -172,6 +176,33 @@ public class ScheduleConverter {
                     .end(null)
                     .build();
         }
+    }
+
+    public static Schedule toShareSchedule(User user, ScheduleRequestDTO.ScheduleCreateDTO request, String shareId){
+
+        FreeTime freeTime = FreeTime.valueOf(request.getFreeTime());
+
+        List<Category> categories = request.getCategories().stream()
+                .map(categoryDTO -> Category.builder()
+                        .name(categoryDTO.getCategoryName())
+                        .color(categoryDTO.getColor())
+                        .build())
+                .collect(Collectors.toList());
+
+        return Schedule.builder()
+                .user(user)
+                .name(request.getName())
+                .body(request.getBody())
+                .meetTime(request.getMeetTime())
+                .place(request.getPlace())
+                .longitude(request.getLongitude())
+                .latitude(request.getLatitude())
+                .moveTime(request.getMoveTime())
+                .freeTime(freeTime)
+                .isRepeat(request.getIsRepeat())
+                .categories(categories)
+                .shareId(shareId)
+                .build();
     }
 
     public static ScheduleResponseDTO.ScheduleStatusDTO toScheduleStatusDTO(Schedule schedule) {

--- a/src/main/java/TImeCAlling/spring/domain/Schedule.java
+++ b/src/main/java/TImeCAlling/spring/domain/Schedule.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Builder
@@ -43,8 +44,8 @@ public class Schedule extends BaseEntity {
     
     @Column(nullable = false)
     private Boolean isRepeat;
-    
-    private Long shareId;
+
+    private String shareId;
     
     @Column(length = 15, nullable = false)
     private String longitude;

--- a/src/main/java/TImeCAlling/spring/domain/Schedule.java
+++ b/src/main/java/TImeCAlling/spring/domain/Schedule.java
@@ -96,4 +96,8 @@ public class Schedule extends BaseEntity {
     public void setRecurringSchedule(RecurringSchedule recurringSchedule) {
         this.recurringSchedule = recurringSchedule;
     }
+
+    public void setShareId(String shareId) {
+        this.shareId = shareId;
+    }
 }

--- a/src/main/java/TImeCAlling/spring/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/TImeCAlling/spring/repository/schedule/ScheduleRepository.java
@@ -19,5 +19,5 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     Optional<Schedule> findByIdAndUser(Long id, User user);
 
-    Optional<List<Schedule>> findByShareId(Long shareId);
+    Optional<List<Schedule>> findByShareId(String shareId);
 }

--- a/src/main/java/TImeCAlling/spring/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/TImeCAlling/spring/repository/schedule/ScheduleRepository.java
@@ -19,6 +19,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     Optional<Schedule> findByIdAndUser(Long id, User user);
 
+    boolean existsByIdAndUser(Long scheduleId, User user);
+
     boolean existsByShareIdAndUser(String shareId, User user);
 
     Optional<List<Schedule>> findByShareId(String shareId);

--- a/src/main/java/TImeCAlling/spring/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/TImeCAlling/spring/repository/schedule/ScheduleRepository.java
@@ -19,5 +19,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     Optional<Schedule> findByIdAndUser(Long id, User user);
 
+    boolean existsByShareIdAndUser(String shareId, User user);
+
     Optional<List<Schedule>> findByShareId(String shareId);
 }

--- a/src/main/java/TImeCAlling/spring/service/schedule/RecurringScheduleService.java
+++ b/src/main/java/TImeCAlling/spring/service/schedule/RecurringScheduleService.java
@@ -6,4 +6,5 @@ import TImeCAlling.spring.web.dto.schedule.ScheduleRequestDTO;
 public interface RecurringScheduleService {
     
     void createRecurringSchedule(Schedule schedule, ScheduleRequestDTO.ScheduleCreateDTO request);
+    void createShareRecurringSchedule(Long scheduleId, Schedule schedule, ScheduleRequestDTO.ScheduleCreateDTO request);
 }

--- a/src/main/java/TImeCAlling/spring/service/schedule/RecurringScheduleServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/schedule/RecurringScheduleServiceImpl.java
@@ -40,13 +40,16 @@ public class RecurringScheduleServiceImpl implements RecurringScheduleService {
                 .map(RepeatDay::valueOf)
                 .collect(Collectors.toSet());
 
-        if (!shareRepeatDays.equals(requestRepeatDays))
+        if (!shareRepeatDays.equals(requestRepeatDays)) {
+            scheduleRepository.delete(schedule);
             throw new ScheduleHandler(ErrorStatus.REPEAT_DAYS_MISMATCH);
-        else if (!shareSchedule.getIsRepeat().equals(request.getIsRepeat()) ||
+        } else if (!shareSchedule.getIsRepeat().equals(request.getIsRepeat()) ||
                 !shareSchedule.getRecurringSchedule().getStart().equals(request.getStart()) ||
-                !shareSchedule.getRecurringSchedule().getEnd().equals(request.getEnd()))
+                !shareSchedule.getRecurringSchedule().getEnd().equals(request.getEnd())) {
+            scheduleRepository.delete(schedule);
             throw new ScheduleHandler(ErrorStatus.RECURRING_MISMATCH);
-
+        }
+        
         RecurringSchedule recurringSchedule = RecurringScheduleConverter.toRecurringSchedule(schedule, request);
         recurringScheduleRepository.save(recurringSchedule);
     }

--- a/src/main/java/TImeCAlling/spring/service/schedule/RecurringScheduleServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/schedule/RecurringScheduleServiceImpl.java
@@ -1,21 +1,52 @@
 package TImeCAlling.spring.service.schedule;
 
+import TImeCAlling.spring.apiPayload.code.status.ErrorStatus;
+import TImeCAlling.spring.apiPayload.exception.handler.ScheduleHandler;
 import TImeCAlling.spring.converter.schedule.RecurringScheduleConverter;
 import TImeCAlling.spring.domain.RecurringSchedule;
 import TImeCAlling.spring.domain.Schedule;
+import TImeCAlling.spring.domain.enums.RepeatDay;
 import TImeCAlling.spring.repository.schedule.RecurringScheduleRepository;
+import TImeCAlling.spring.repository.schedule.ScheduleRepository;
 import TImeCAlling.spring.web.dto.schedule.ScheduleRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class RecurringScheduleServiceImpl implements RecurringScheduleService {
     
     private final RecurringScheduleRepository recurringScheduleRepository;
+    private final ScheduleRepository scheduleRepository;
     
     @Override
     public void createRecurringSchedule(Schedule schedule, ScheduleRequestDTO.ScheduleCreateDTO request) {
+        RecurringSchedule recurringSchedule = RecurringScheduleConverter.toRecurringSchedule(schedule, request);
+        recurringScheduleRepository.save(recurringSchedule);
+    }
+
+    @Override
+    public void createShareRecurringSchedule(Long scheduleId, Schedule schedule, ScheduleRequestDTO.ScheduleCreateDTO request) {
+
+        Schedule shareSchedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new ScheduleHandler(ErrorStatus.SCHEDULE_NOT_FOUND));
+
+        Set<RepeatDay> shareRepeatDays = new HashSet<>(shareSchedule.getRecurringSchedule().getRepeatDays());
+        Set<RepeatDay> requestRepeatDays = request.getRepeatDays().stream()
+                .map(RepeatDay::valueOf)
+                .collect(Collectors.toSet());
+
+        if (!shareRepeatDays.equals(requestRepeatDays))
+            throw new ScheduleHandler(ErrorStatus.REPEAT_DAYS_MISMATCH);
+        else if (!shareSchedule.getIsRepeat().equals(request.getIsRepeat()) ||
+                !shareSchedule.getRecurringSchedule().getStart().equals(request.getStart()) ||
+                !shareSchedule.getRecurringSchedule().getEnd().equals(request.getEnd()))
+            throw new ScheduleHandler(ErrorStatus.RECURRING_MISMATCH);
+
         RecurringSchedule recurringSchedule = RecurringScheduleConverter.toRecurringSchedule(schedule, request);
         recurringScheduleRepository.save(recurringSchedule);
     }

--- a/src/main/java/TImeCAlling/spring/service/schedule/RecurringScheduleServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/schedule/RecurringScheduleServiceImpl.java
@@ -32,8 +32,7 @@ public class RecurringScheduleServiceImpl implements RecurringScheduleService {
     @Override
     public void createShareRecurringSchedule(Long scheduleId, Schedule schedule, ScheduleRequestDTO.ScheduleCreateDTO request) {
 
-        Schedule shareSchedule = scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new ScheduleHandler(ErrorStatus.SCHEDULE_NOT_FOUND));
+        Schedule shareSchedule = scheduleRepository.findById(scheduleId).get();
 
         Set<RepeatDay> shareRepeatDays = new HashSet<>(shareSchedule.getRecurringSchedule().getRepeatDays());
         Set<RepeatDay> requestRepeatDays = request.getRepeatDays().stream()

--- a/src/main/java/TImeCAlling/spring/service/schedule/ScheduleCommandService.java
+++ b/src/main/java/TImeCAlling/spring/service/schedule/ScheduleCommandService.java
@@ -8,4 +8,5 @@ public interface ScheduleCommandService {
     public Schedule createSchedule(User user, ScheduleRequestDTO.ScheduleCreateDTO request);
     public Schedule patchSchedule(Long scheduleId, User user, ScheduleRequestDTO.SchedulePatchDTO request);
     public Schedule deleteSchedule(Long scheduleId, User user);
+    public Schedule createShareSchedule(User user, Long scheduleId, ScheduleRequestDTO.ScheduleCreateDTO request);
 }

--- a/src/main/java/TImeCAlling/spring/service/schedule/ScheduleCommandServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/schedule/ScheduleCommandServiceImpl.java
@@ -125,25 +125,40 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
     @Override
     public Schedule createShareSchedule(User user, Long scheduleId, ScheduleRequestDTO.ScheduleCreateDTO request) {
 
-        Optional<Schedule> shareSchedule = scheduleRepository.findById(scheduleId);
-
-        shareSchedule.ifPresent(schedule -> {
-            if (schedule.getShareId() == null) {
-                String shareId = UUID.randomUUID().toString();
-                schedule.setShareId(shareId);
-                scheduleRepository.save(schedule);
-            }
-        });
-        String shareId = shareSchedule
-                .map(Schedule::getShareId)
+        Schedule shareSchedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new ScheduleHandler(ErrorStatus.SCHEDULE_NOT_FOUND));
 
+        // 공유 일정과 기본 정보 일치하는지 확인
+        if (!shareSchedule.getName().equals(request.getName()))
+            throw new ScheduleHandler(ErrorStatus.SCHEDULE_NAME_MISMATCH);
+        else if (!shareSchedule.getChecklists().get(0).getDate().equals(request.getMeetDate()))
+            throw new ScheduleHandler(ErrorStatus.SCHEDULE_DATE_MISMATCH);
+        else if (!shareSchedule.getMeetTime().equals(request.getMeetTime()))
+            throw new ScheduleHandler(ErrorStatus.SCHEDULE_TIME_MISMATCH);
+        else if (!shareSchedule.getPlace().equals(request.getPlace()))
+            throw new ScheduleHandler(ErrorStatus.SCHEDULE_PLACE_MISMATCH);
+        else if (!shareSchedule.getLongitude().equals(request.getLongitude()))
+            throw new ScheduleHandler(ErrorStatus.SCHEDULE_LONGITUDE_MISMATCH);
+        else if (!shareSchedule.getLatitude().equals(request.getLatitude()))
+            throw new ScheduleHandler(ErrorStatus.SCHEDULE_LATITUDE_MISMATCH);
+
+        // 공유 id 생성
+        String shareId = getShareId(shareSchedule);
         if (scheduleRepository.existsByShareIdAndUser(shareId, user)) {
             throw new ScheduleHandler(ErrorStatus.SCHEDULE_ALREADY_EXIST);
         }
 
         Schedule newSchedule = ScheduleConverter.toShareSchedule(user, request, shareId);
         return scheduleRepository.save(newSchedule);
+    }
+
+    private String getShareId(Schedule schedule) {
+        if (schedule.getShareId() == null) {
+            String shareId = UUID.randomUUID().toString();
+            schedule.setShareId(shareId);
+            scheduleRepository.save(schedule);
+        }
+        return schedule.getShareId();
     }
 
     // 두 리스트 값 비교 메서드

--- a/src/main/java/TImeCAlling/spring/service/schedule/ScheduleCommandServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/schedule/ScheduleCommandServiceImpl.java
@@ -14,9 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -123,7 +121,20 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
         }
         return schedule;
     }
-    
+
+    @Override
+    public Schedule createShareSchedule(User user, Long scheduleId, ScheduleRequestDTO.ScheduleCreateDTO request) {
+
+        Optional<Schedule> shareSchedule = scheduleRepository.findById(scheduleId);
+        String shareId = shareSchedule
+                .map(schedule -> schedule.getShareId() != null ? schedule.getShareId() : UUID.randomUUID().toString()
+                )
+                .orElseThrow(() -> new ScheduleHandler(ErrorStatus.SCHEDULE_NOT_FOUND));
+
+        Schedule newSchedule = ScheduleConverter.toShareSchedule(user, request, shareId);
+        return scheduleRepository.save(newSchedule);
+    }
+
     // 두 리스트 값 비교 메서드
     
     private static boolean areListsEqual(List<?> list1, List<?> list2) {

--- a/src/main/java/TImeCAlling/spring/service/schedule/ScheduleCommandServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/schedule/ScheduleCommandServiceImpl.java
@@ -126,10 +126,21 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
     public Schedule createShareSchedule(User user, Long scheduleId, ScheduleRequestDTO.ScheduleCreateDTO request) {
 
         Optional<Schedule> shareSchedule = scheduleRepository.findById(scheduleId);
+
+        shareSchedule.ifPresent(schedule -> {
+            if (schedule.getShareId() == null) {
+                String shareId = UUID.randomUUID().toString();
+                schedule.setShareId(shareId);
+                scheduleRepository.save(schedule);
+            }
+        });
         String shareId = shareSchedule
-                .map(schedule -> schedule.getShareId() != null ? schedule.getShareId() : UUID.randomUUID().toString()
-                )
+                .map(Schedule::getShareId)
                 .orElseThrow(() -> new ScheduleHandler(ErrorStatus.SCHEDULE_NOT_FOUND));
+
+        if (scheduleRepository.existsByShareIdAndUser(shareId, user)) {
+            throw new ScheduleHandler(ErrorStatus.SCHEDULE_ALREADY_EXIST);
+        }
 
         Schedule newSchedule = ScheduleConverter.toShareSchedule(user, request, shareId);
         return scheduleRepository.save(newSchedule);

--- a/src/main/java/TImeCAlling/spring/service/schedule/ScheduleCommandServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/schedule/ScheduleCommandServiceImpl.java
@@ -125,8 +125,7 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
     @Override
     public Schedule createShareSchedule(User user, Long scheduleId, ScheduleRequestDTO.ScheduleCreateDTO request) {
 
-        Schedule shareSchedule = scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new ScheduleHandler(ErrorStatus.SCHEDULE_NOT_FOUND));
+        Schedule shareSchedule = scheduleRepository.findById(scheduleId).get();
 
         // 공유 일정과 기본 정보 일치하는지 확인
         if (!shareSchedule.getName().equals(request.getName()))

--- a/src/main/java/TImeCAlling/spring/service/schedule/ScheduleQueryService.java
+++ b/src/main/java/TImeCAlling/spring/service/schedule/ScheduleQueryService.java
@@ -9,6 +9,7 @@ import java.util.List;
 public interface ScheduleQueryService {
     public Schedule getScheduleWithChecklist(Long checklistId, User user);
     public Schedule getSchedule(Long scheduleId, User user);
+    public Schedule getShareSchedule(Long scheduleId, User user);
     public Schedule getSchedule(Long scheduleId);
     public List<ScheduleResponseDTO.SharedScheduleUserDTO> getSharedScheduleUsers(Schedule schedule);
 }

--- a/src/main/java/TImeCAlling/spring/service/schedule/ScheduleQueryServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/schedule/ScheduleQueryServiceImpl.java
@@ -41,8 +41,7 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
             throw new ScheduleHandler(ErrorStatus.SCHEDULE_ALREADY_EXIST);
         }
 
-        return scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new ScheduleHandler(ErrorStatus.SCHEDULE_NOT_FOUND));
+        return scheduleRepository.findById(scheduleId).get();
     }
 
     @Override

--- a/src/main/java/TImeCAlling/spring/service/schedule/ScheduleQueryServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/schedule/ScheduleQueryServiceImpl.java
@@ -30,7 +30,19 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
     @ExistSchedule
     public Schedule getSchedule(Long scheduleId, User user) {
         
-        return scheduleRepository.findByIdAndUser(scheduleId, user).orElseThrow(() -> new ScheduleHandler(ErrorStatus._BAD_REQUEST));
+        return scheduleRepository.findByIdAndUser(scheduleId, user)
+                .orElseThrow(() -> new ScheduleHandler(ErrorStatus._BAD_REQUEST));
+    }
+
+    @Override
+    public Schedule getShareSchedule(Long scheduleId, User user) {
+
+        if (scheduleRepository.existsByIdAndUser(scheduleId, user)) {
+            throw new ScheduleHandler(ErrorStatus.SCHEDULE_ALREADY_EXIST);
+        }
+
+        return scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new ScheduleHandler(ErrorStatus.SCHEDULE_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/TImeCAlling/spring/web/controller/schedule/ScheduleController.java
+++ b/src/main/java/TImeCAlling/spring/web/controller/schedule/ScheduleController.java
@@ -80,6 +80,14 @@ public class ScheduleController {
         Schedule schedule = scheduleCommandService.deleteSchedule(scheduleId, user);
         return ApiResponse.onSuccess(ScheduleConverter.toScheduleCommandDTO(scheduleId));
     }
+
+    @Operation(summary = "공유 일정 조회", description = "일정 id로 일정의 정보를 조회합니다.")
+    @GetMapping("/share/{scheduleId}")
+    public ApiResponse<ScheduleResponseDTO.GetShareScheduleDTO> getShareSchedule(@AuthenticationPrincipal User user, @PathVariable @ExistSchedule Long scheduleId) {
+
+        Schedule schedule = scheduleQueryService.getSchedule(scheduleId, user);
+        return ApiResponse.onSuccess(ScheduleConverter.toGetShareScheduleDTO(user, schedule, schedule.getRecurringSchedule() == null ? null : schedule.getRecurringSchedule()));
+    }
     
     @Operation(summary = "준비중 일정 조회 API", description = "일정 id로 조회시 해당 일정의 준비중 상태를 조회합니다.")
     @GetMapping("/{scheduleId}/status")

--- a/src/main/java/TImeCAlling/spring/web/controller/schedule/ScheduleController.java
+++ b/src/main/java/TImeCAlling/spring/web/controller/schedule/ScheduleController.java
@@ -95,7 +95,7 @@ public class ScheduleController {
 
         Schedule schedule = scheduleCommandService.createShareSchedule(user, scheduleId, request);
         if (request.getIsRepeat()) {
-            recurringScheduleService.createRecurringSchedule(schedule, request);
+            recurringScheduleService.createShareRecurringSchedule(scheduleId, schedule, request);
         }
         checklistCommandService.createChecklists(schedule, request);
 

--- a/src/main/java/TImeCAlling/spring/web/controller/schedule/ScheduleController.java
+++ b/src/main/java/TImeCAlling/spring/web/controller/schedule/ScheduleController.java
@@ -85,7 +85,7 @@ public class ScheduleController {
     @GetMapping("/share/{scheduleId}")
     public ApiResponse<ScheduleResponseDTO.GetShareScheduleDTO> getShareSchedule(@AuthenticationPrincipal User user, @PathVariable @ExistSchedule Long scheduleId) {
 
-        Schedule schedule = scheduleQueryService.getSchedule(scheduleId, user);
+        Schedule schedule = scheduleQueryService.getShareSchedule(scheduleId, user);
         return ApiResponse.onSuccess(ScheduleConverter.toGetShareScheduleDTO(user, schedule, schedule.getRecurringSchedule() == null ? null : schedule.getRecurringSchedule()));
     }
 

--- a/src/main/java/TImeCAlling/spring/web/controller/schedule/ScheduleController.java
+++ b/src/main/java/TImeCAlling/spring/web/controller/schedule/ScheduleController.java
@@ -81,14 +81,27 @@ public class ScheduleController {
         return ApiResponse.onSuccess(ScheduleConverter.toScheduleCommandDTO(scheduleId));
     }
 
-    @Operation(summary = "공유 일정 조회", description = "일정 id로 일정의 정보를 조회합니다.")
+    @Operation(summary = "공유 일정 조회", description = "일정 id로 공유 일정의 정보를 조회합니다.")
     @GetMapping("/share/{scheduleId}")
     public ApiResponse<ScheduleResponseDTO.GetShareScheduleDTO> getShareSchedule(@AuthenticationPrincipal User user, @PathVariable @ExistSchedule Long scheduleId) {
 
         Schedule schedule = scheduleQueryService.getSchedule(scheduleId, user);
         return ApiResponse.onSuccess(ScheduleConverter.toGetShareScheduleDTO(user, schedule, schedule.getRecurringSchedule() == null ? null : schedule.getRecurringSchedule()));
     }
-    
+
+    @Operation(summary = "공유 일정 추가", description = "공유 일정을 추가합니다. meetTime에 HH:mm 형식만 입력 가능합니다!")
+    @PostMapping("/share/{scheduleId}")
+    public ApiResponse<ScheduleResponseDTO.ScheduleCreateDTO> createShareSchedule(@AuthenticationPrincipal User user, @PathVariable @ExistSchedule Long scheduleId, @RequestBody @Valid ScheduleRequestDTO.ScheduleCreateDTO request) {
+
+        Schedule schedule = scheduleCommandService.createShareSchedule(user, scheduleId, request);
+        if (request.getIsRepeat()) {
+            recurringScheduleService.createRecurringSchedule(schedule, request);
+        }
+        checklistCommandService.createChecklists(schedule, request);
+
+        return ApiResponse.onSuccess(ScheduleConverter.toScheduleCreateDTO(schedule));
+    }
+
     @Operation(summary = "준비중 일정 조회 API", description = "일정 id로 조회시 해당 일정의 준비중 상태를 조회합니다.")
     @GetMapping("/{scheduleId}/status")
     public ApiResponse<ScheduleResponseDTO.ScheduleStatusDTO> getScheduleStatus(

--- a/src/main/java/TImeCAlling/spring/web/dto/schedule/ScheduleRequestDTO.java
+++ b/src/main/java/TImeCAlling/spring/web/dto/schedule/ScheduleRequestDTO.java
@@ -4,6 +4,7 @@ import TImeCAlling.spring.domain.enums.FreeTime;
 import TImeCAlling.spring.domain.enums.RepeatDay;
 import TImeCAlling.spring.validation.annotation.ValidEnum;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -43,6 +44,7 @@ public class ScheduleRequestDTO {
         LocalDate meetDate;
 
         @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "00:00")
         @NotNull
         LocalTime meetTime;
 
@@ -58,10 +60,12 @@ public class ScheduleRequestDTO {
         @NotNull
         Integer moveTime;
 
+        @Schema(example = "TIGHT")
         @NotNull
         @ValidEnum(enumClass = FreeTime.class)
         String freeTime;
-        
+
+        @Schema(example = "[\"MONDAY\", \"TUESDAY\"]")
         @ValidEnum(enumClass = RepeatDay.class)
         List<String> repeatDays;
 
@@ -89,6 +93,7 @@ public class ScheduleRequestDTO {
         LocalDate meetDate;
 
         @JsonFormat(pattern = "HH:mm")
+        @Schema(type = "string", example = "00:00")
         @NotNull
         LocalTime meetTime;
         
@@ -104,13 +109,15 @@ public class ScheduleRequestDTO {
         @NotNull
         Integer moveTime;
 
+        @Schema(example = "TIGHT")
         @NotNull
         @ValidEnum(enumClass = FreeTime.class)
         String freeTime;
 
         @NotNull
         Boolean isRepeat;
-        
+
+        @Schema(example = "[\"MONDAY\", \"TUESDAY\"]")
         @ValidEnum(enumClass = RepeatDay.class)
         List<String> repeatDays;
         

--- a/src/main/java/TImeCAlling/spring/web/dto/schedule/ScheduleResponseDTO.java
+++ b/src/main/java/TImeCAlling/spring/web/dto/schedule/ScheduleResponseDTO.java
@@ -50,6 +50,7 @@ public class ScheduleResponseDTO {
         LocalDate start;
         LocalDate end;
         List<CategoryDTO> categories;
+        String shareId;
     }
     
     @Builder

--- a/src/main/java/TImeCAlling/spring/web/dto/schedule/ScheduleResponseDTO.java
+++ b/src/main/java/TImeCAlling/spring/web/dto/schedule/ScheduleResponseDTO.java
@@ -36,6 +36,7 @@ public class ScheduleResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ScheduleGetDTO{
+        Long scheduleId;
         String name;
         LocalDate meetDate;
 

--- a/src/main/java/TImeCAlling/spring/web/dto/schedule/ScheduleResponseDTO.java
+++ b/src/main/java/TImeCAlling/spring/web/dto/schedule/ScheduleResponseDTO.java
@@ -18,6 +18,7 @@ public class ScheduleResponseDTO {
     @AllArgsConstructor
     public static class ScheduleCreateDTO{
         Long scheduleId;
+        String shareId;
         LocalDateTime createdAt;
     }
 
@@ -57,6 +58,26 @@ public class ScheduleResponseDTO {
     @AllArgsConstructor
     public static class ScheduleDeleteDTO{
         Long scheduleId;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetShareScheduleDTO {
+        String nickname;
+        String name;
+        LocalDate meetDate;
+
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime meetTime;
+        String place;
+        String longitude;
+        String latitude;
+        List<String> repeatDays;
+        Boolean isRepeat;
+        LocalDate start;
+        LocalDate end;
     }
   
     @Builder


### PR DESCRIPTION
## Issue

- #67 

## Summary

- 공유 링크 접속 시, 공유 일정의 기본 정보를 불러오는 로직과 공유 일정을 추가하는 로직 구현
- GET /api/schedules/share/{scheduleId}
- POST /api/schedules/share/{scheduleId}

## Describe your code

- shareId를 UUID로 생성하는 방법을 사용했기 때문에 기존 Long 타입에서 String으로 변경하였습니다!
- 공유 링크 접속 시, scheduleId가 로그인 한 유저의 일정이면 SCHEDULE_ALREADY_EXIST 예외 처리 하였습니다
- 공유 일정을 다른 유저가 추가할 때 shareId가 생성되며, shareId가 존재하는 일정은 기본 정보 외에 수정이 불가능합니다
- 반복 요일은 입력 순서에 상관없게 검증하도록 작성하였습니다
- 공유 일정 수정 로직, 일정 생성/수정 시 반복 설정 검증 로직은 다른 이슈에서 추가로 작업할 예정입니다 :)

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
