### PR TITLE
[FIX/FEAT] 로그아웃 및 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/TImeCAlling/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TImeCAlling/spring/apiPayload/code/status/ErrorStatus.java
@@ -23,7 +23,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 토큰 관련 에러
     NOT_VALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 토큰입니다."),
     WRONG_TYPE_SIGNATURE(HttpStatus.UNAUTHORIZED, "TOKEN4002", "잘못된 JWT 서명입니다."),
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN4003", "토큰이 만료되었습니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN4003", "액세스 토큰이 만료되었습니다."),
     WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4004", "지원되지 않는 JWT 토큰입니다."),
     ACCESS_TOKEN_NOT_EXPIRED(HttpStatus.BAD_REQUEST, "TOKEN4005", "액세스 토큰이 만료되지 않았습니다."),
     INVALID_KAKAO_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4006", "카카오 액세스 토큰이 유효하지 않습니다."),

--- a/src/main/java/TImeCAlling/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TImeCAlling/spring/apiPayload/code/status/ErrorStatus.java
@@ -19,6 +19,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 유저 관련 에러
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001", "유저를 찾을 수 없습니다."),
     USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "이미 존재하는 유저입니다."),
+    LOGGED_OUT_USER(HttpStatus.NOT_FOUND, "USER4003", "로그아웃한 유저입니다."),
 
     // 토큰 관련 에러
     NOT_VALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 토큰입니다."),

--- a/src/main/java/TImeCAlling/spring/auth/JwtUtil.java
+++ b/src/main/java/TImeCAlling/spring/auth/JwtUtil.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -77,7 +78,7 @@ public class JwtUtil {
         }
     }
 
-    public Authentication getAuthentication(String token) {
+    public Authentication getAuthentication(String token) throws UsernameNotFoundException {
         UserDetails userDetails = userDetailService.loadUserByUserId(this.getUserId(token));
         return new UsernamePasswordAuthenticationToken(userDetails, null, null);
     }

--- a/src/main/java/TImeCAlling/spring/auth/filter/JwtExceptionHandlerFilter.java
+++ b/src/main/java/TImeCAlling/spring/auth/filter/JwtExceptionHandlerFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -22,7 +23,7 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
 
         try {
             filterChain.doFilter(request, response);
-        } catch (JwtExceptionHandler ex) {
+        } catch (JwtExceptionHandler | UsernameNotFoundException ex) {
             setErrorResponse(HttpStatus.UNAUTHORIZED, request, response, ex);
         }
     }

--- a/src/main/java/TImeCAlling/spring/config/SwaggerConfig.java
+++ b/src/main/java/TImeCAlling/spring/config/SwaggerConfig.java
@@ -19,22 +19,16 @@ public class SwaggerConfig {
                 .description("TImeCAlling API 명세서")
                 .version("1.0.0");
 
-        String accessTokenSchemeName = "accessToken";
-        String refreshTokenSchemeName = "refreshToken";
+        String jwtSchemeName = "Authorization";
 
         // API 요청헤더에 인증정보 포함
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList(accessTokenSchemeName);
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
 
         // SecuritySchemes 등록
         Components components = new Components()
-                .addSecuritySchemes(accessTokenSchemeName, new SecurityScheme()
-                        .name("accessToken")
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
                         .type(SecurityScheme.Type.HTTP) // HTTP 방식
-                        .scheme("bearer")
-                        .bearerFormat("JWT"))
-                .addSecuritySchemes(refreshTokenSchemeName, new SecurityScheme()
-                        .name("refreshToken")
-                        .type(SecurityScheme.Type.HTTP)
                         .scheme("bearer")
                         .bearerFormat("JWT"));
         

--- a/src/main/java/TImeCAlling/spring/converter/user/UserConverter.java
+++ b/src/main/java/TImeCAlling/spring/converter/user/UserConverter.java
@@ -83,4 +83,10 @@ public class UserConverter {
                 .accessToken(accessToken)
                 .build();
     }
+
+    public static UserResponseDTO.UserIdDTO toUserIdDTO(User user) {
+        return UserResponseDTO.UserIdDTO.builder()
+                .userId(user.getId())
+                .build();
+    }
 }

--- a/src/main/java/TImeCAlling/spring/service/user/UserCommandService.java
+++ b/src/main/java/TImeCAlling/spring/service/user/UserCommandService.java
@@ -7,7 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface UserCommandService {
     
     UserResponseDTO.UserSignUpResultDTO createUser(MultipartFile profileImage, UserRequestDTO.UserCreateDTO userCreateDTO);
-    UserResponseDTO.UserDeleteDTO deleteUser(Long id);
+    UserResponseDTO.UserIdDTO deleteUser(Long id);
     UserResponseDTO.UserUpdateDTO updateUser(Long id, MultipartFile profileImage, UserRequestDTO.UserUpdateDTO updateDTO);
     UserResponseDTO.UserMyPageDTO findMyUsers(Long id);
     UserResponseDTO.UserSignUpResultDTO kakaoSignUp(MultipartFile profileImage, UserRequestDTO.UserSignUpDTO request);

--- a/src/main/java/TImeCAlling/spring/service/user/UserCommandService.java
+++ b/src/main/java/TImeCAlling/spring/service/user/UserCommandService.java
@@ -1,5 +1,6 @@
 package TImeCAlling.spring.service.user;
 
+import TImeCAlling.spring.domain.User;
 import TImeCAlling.spring.web.dto.user.UserRequestDTO;
 import TImeCAlling.spring.web.dto.user.UserResponseDTO;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,4 +16,5 @@ public interface UserCommandService {
     UserResponseDTO.RefreshTokenResultDTO refreshToken(UserRequestDTO.RefreshTokenDTO request);
     UserResponseDTO.UserSignUpResultDTO createToken(Long userId);
     String getAccessToken(String code);
+    User logout(User user);
 }

--- a/src/main/java/TImeCAlling/spring/service/user/UserCommandService.java
+++ b/src/main/java/TImeCAlling/spring/service/user/UserCommandService.java
@@ -8,7 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface UserCommandService {
     
     UserResponseDTO.UserSignUpResultDTO createUser(MultipartFile profileImage, UserRequestDTO.UserCreateDTO userCreateDTO);
-    UserResponseDTO.UserIdDTO deleteUser(Long id);
+    UserResponseDTO.UserIdDTO deleteUser(User user);
     UserResponseDTO.UserUpdateDTO updateUser(Long id, MultipartFile profileImage, UserRequestDTO.UserUpdateDTO updateDTO);
     UserResponseDTO.UserMyPageDTO findMyUsers(Long id);
     UserResponseDTO.UserSignUpResultDTO kakaoSignUp(MultipartFile profileImage, UserRequestDTO.UserSignUpDTO request);

--- a/src/main/java/TImeCAlling/spring/service/user/UserCommandService.java
+++ b/src/main/java/TImeCAlling/spring/service/user/UserCommandService.java
@@ -9,8 +9,7 @@ public interface UserCommandService {
     
     UserResponseDTO.UserSignUpResultDTO createUser(MultipartFile profileImage, UserRequestDTO.UserCreateDTO userCreateDTO);
     UserResponseDTO.UserIdDTO deleteUser(User user);
-    UserResponseDTO.UserUpdateDTO updateUser(Long id, MultipartFile profileImage, UserRequestDTO.UserUpdateDTO updateDTO);
-    UserResponseDTO.UserMyPageDTO findMyUsers(Long id);
+    UserResponseDTO.UserUpdateDTO updateUser(User user, MultipartFile profileImage, UserRequestDTO.UserUpdateDTO updateDTO);
     UserResponseDTO.UserSignUpResultDTO kakaoSignUp(MultipartFile profileImage, UserRequestDTO.UserSignUpDTO request);
     UserResponseDTO.UserSignUpResultDTO kakaoLogin(UserRequestDTO.UserLoginDTO request);
     UserResponseDTO.RefreshTokenResultDTO refreshToken(UserRequestDTO.RefreshTokenDTO request);

--- a/src/main/java/TImeCAlling/spring/service/user/UserCommandServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/user/UserCommandServiceImpl.java
@@ -65,7 +65,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
     
     @Override
-    public UserResponseDTO.UserDeleteDTO deleteUser(Long id) {
+    public UserResponseDTO.UserIdDTO deleteUser(Long id) {
         
         User findUser = getFindUser(id);
 
@@ -74,7 +74,7 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         userRepository.delete(findUser);
         
-        return UserResponseDTO.UserDeleteDTO.builder()
+        return UserResponseDTO.UserIdDTO.builder()
                 .userId(findUser.getId())
                 .build();
     }

--- a/src/main/java/TImeCAlling/spring/service/user/UserCommandServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/user/UserCommandServiceImpl.java
@@ -274,4 +274,13 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         return UserConverter.toUserSignUpResultDTO(findUser, accessToken, refreshToken);
     }
+
+    @Override
+    public User logout(User user) {
+
+        // DB에 저장된 refreshToken 삭제
+        user.setRefreshToken(null);
+
+        return userRepository.save(user);
+    }
 }

--- a/src/main/java/TImeCAlling/spring/service/user/UserCommandServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/user/UserCommandServiceImpl.java
@@ -82,14 +82,12 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
     
     @Override
-    public UserResponseDTO.UserUpdateDTO updateUser(Long id, MultipartFile profileImage, UserRequestDTO.UserUpdateDTO updateDTO) {
-        
-        User findUser = getFindUser(id);
+    public UserResponseDTO.UserUpdateDTO updateUser(User user, MultipartFile profileImage, UserRequestDTO.UserUpdateDTO updateDTO) {
 
         FreeTime freeTime = updateDTO.getFreeTime() != null ? FreeTime.valueOf(updateDTO.getFreeTime()) : null;
 
         if (profileImage != null) {
-            ProfileImage image = findUser.getProfileImage();
+            ProfileImage image = user.getProfileImage();
             s3Service.deleteImageFromS3(image.getFileUrl());
 
             String newImageUrl = s3Service.uploadFile(profileImage);
@@ -97,21 +95,9 @@ public class UserCommandServiceImpl implements UserCommandService {
             image.update(newImageUrl, fileName);
         }
 
-        findUser.update(updateDTO.getNickname(), updateDTO.getAvgPrepTime(), freeTime);
+        user.update(updateDTO.getNickname(), updateDTO.getAvgPrepTime(), freeTime);
 
-        return UserConverter.toUserUpdateDTO(userRepository.save(findUser));
-    }
-    
-    @Override
-    public UserResponseDTO.UserMyPageDTO findMyUsers(Long id) {
-        
-        User findUser = getFindUser(id);
-
-        return UserConverter.toUserMyPageDTO(findUser);
-    }
-    
-    private User getFindUser(Long id) {
-        return userRepository.findById(id).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        return UserConverter.toUserUpdateDTO(userRepository.save(user));
     }
 
     @Override

--- a/src/main/java/TImeCAlling/spring/service/user/UserCommandServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/user/UserCommandServiceImpl.java
@@ -252,6 +252,8 @@ public class UserCommandServiceImpl implements UserCommandService {
         User findUser = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
+        if (findUser.getRefreshToken() == null)
+            throw new UserHandler(ErrorStatus.LOGGED_OUT_USER);
         if (!Objects.equals(findUser.getRefreshToken(), refreshToken))
             throw new TokenHandler(ErrorStatus.REFRESH_TOKEN_MISMATCH);
 

--- a/src/main/java/TImeCAlling/spring/service/user/UserCommandServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/user/UserCommandServiceImpl.java
@@ -20,11 +20,13 @@ import TImeCAlling.spring.web.dto.user.UserResponseDTO;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.BufferedReader;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
@@ -44,6 +46,8 @@ public class UserCommandServiceImpl implements UserCommandService {
     private final S3Service s3Service;
     private final JwtUtil jwtUtil;
     private final Gson gson;
+    @Value("${spring.kakao.admin-key}")
+    private String adminKey;
     
     @Override
     public UserResponseDTO.UserSignUpResultDTO createUser(MultipartFile profileImage, UserRequestDTO.UserCreateDTO userCreateDTO) {
@@ -65,18 +69,16 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
     
     @Override
-    public UserResponseDTO.UserIdDTO deleteUser(Long id) {
-        
-        User findUser = getFindUser(id);
+    public UserResponseDTO.UserIdDTO deleteUser(User user) {
 
-        String imageUrl = findUser.getProfileImage().getFileUrl();
+        String imageUrl = user.getProfileImage().getFileUrl();
         s3Service.deleteImageFromS3(imageUrl);
 
-        userRepository.delete(findUser);
+        unlinkKakaoAccount(user.getSocialId());
+
+        userRepository.delete(user);
         
-        return UserResponseDTO.UserIdDTO.builder()
-                .userId(findUser.getId())
-                .build();
+        return UserConverter.toUserIdDTO(user);
     }
     
     @Override
@@ -155,52 +157,6 @@ public class UserCommandServiceImpl implements UserCommandService {
         userRepository.save(findUser);
 
         return UserConverter.toUserSignUpResultDTO(findUser, accessToken, refreshToken);
-    }
-
-    private UserAuthDTO.KaKaoUserInfoDTO getUserInfo(String accessToken) {
-
-        String getURL = "https://kapi.kakao.com/v2/user/me";
-        StringBuilder result;
-
-        try {
-            URL url = new URL(getURL);
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestMethod("GET");
-            conn.setRequestProperty("Authorization", "Bearer " + accessToken);
-
-            int responseCode = conn.getResponseCode();  // 응답 코드
-            System.out.println("responseCode : " + responseCode);
-
-            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-            String line = "";
-            result = new StringBuilder();
-
-            while ((line = br.readLine()) != null) {
-                result.append(line);
-            }
-            System.out.println("response body : " + result);
-
-        } catch (IOException exception) {
-            throw new TokenHandler(ErrorStatus.INVALID_KAKAO_TOKEN);
-        }
-
-        return gson.fromJson(result.toString(), UserAuthDTO.KaKaoUserInfoDTO.class);
-    }
-
-    private String getFileName(String imageUrl) {
-
-        String fileName;
-
-        try {
-            URL url = new URL(imageUrl);
-            String path = url.getPath();
-            fileName = path.substring(path.lastIndexOf("/") + 1);
-
-        } catch (MalformedURLException e) {
-            throw new S3Handler(ErrorStatus.INVALID_URL);
-        }
-
-        return fileName;
     }
 
     @Override
@@ -284,5 +240,80 @@ public class UserCommandServiceImpl implements UserCommandService {
         user.setRefreshToken(null);
 
         return userRepository.save(user);
+    }
+
+    private UserAuthDTO.KaKaoUserInfoDTO getUserInfo(String accessToken) {
+
+        String getURL = "https://kapi.kakao.com/v2/user/me";
+        StringBuilder result;
+
+        try {
+            URL url = new URL(getURL);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+
+            int responseCode = conn.getResponseCode();  // 응답 코드
+            System.out.println("responseCode : " + responseCode);
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String line = "";
+            result = new StringBuilder();
+
+            while ((line = br.readLine()) != null) {
+                result.append(line);
+            }
+            System.out.println("response body : " + result);
+
+        } catch (IOException exception) {
+            throw new TokenHandler(ErrorStatus.INVALID_KAKAO_TOKEN);
+        }
+
+        return gson.fromJson(result.toString(), UserAuthDTO.KaKaoUserInfoDTO.class);
+    }
+
+    private String getFileName(String imageUrl) {
+
+        String fileName;
+
+        try {
+            URL url = new URL(imageUrl);
+            String path = url.getPath();
+            fileName = path.substring(path.lastIndexOf("/") + 1);
+
+        } catch (MalformedURLException e) {
+            throw new S3Handler(ErrorStatus.INVALID_URL);
+        }
+
+        return fileName;
+    }
+
+    private void unlinkKakaoAccount(Long socialId) {
+        String postURL = "https://kapi.kakao.com/v1/user/unlink";
+        StringBuilder result;
+        try {
+            URL url = new URL(postURL);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Authorization", "KakaoAK " + adminKey);
+            conn.setDoOutput(true);
+            String postParams = "target_id_type=user_id&target_id=" + socialId;
+            try (DataOutputStream wr = new DataOutputStream(conn.getOutputStream())) {
+                wr.writeBytes(postParams);
+                wr.flush();
+            }
+            int responseCode = conn.getResponseCode();  // 응답 코드
+            System.out.println("responseCode : " + responseCode);
+            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String line = "";
+            result = new StringBuilder();
+            while ((line = br.readLine()) != null) {
+                result.append(line);
+            }
+            br.close();
+            System.out.println("response body : " + result);
+        } catch (IOException ex) {
+            throw new RuntimeException("카카오 계정의 연결을 끊는데 실패하였습니다.", ex);
+        }
     }
 }

--- a/src/main/java/TImeCAlling/spring/service/user/UserDetailService.java
+++ b/src/main/java/TImeCAlling/spring/service/user/UserDetailService.java
@@ -1,7 +1,5 @@
 package TImeCAlling.spring.service.user;
 
-import TImeCAlling.spring.apiPayload.code.status.ErrorStatus;
-import TImeCAlling.spring.apiPayload.exception.handler.UserHandler;
 import TImeCAlling.spring.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,12 +19,12 @@ public class UserDetailService implements UserDetailsService {
     public UserDetails loadUserByUsername(String nickname) {
 
         return userRepository.findByNickname(nickname).orElseThrow(
-                () -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+                () -> new UsernameNotFoundException("유저를 찾을 수 없습니다."));
     }
 
     public UserDetails loadUserByUserId(Long id) throws UsernameNotFoundException {
 
         return userRepository.findById(id).orElseThrow(
-                () -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+                () -> new UsernameNotFoundException("유저를 찾을 수 없습니다. userId: " + id));
     }
 }

--- a/src/main/java/TImeCAlling/spring/service/user/UserDetailService.java
+++ b/src/main/java/TImeCAlling/spring/service/user/UserDetailService.java
@@ -1,5 +1,6 @@
 package TImeCAlling.spring.service.user;
 
+import TImeCAlling.spring.domain.User;
 import TImeCAlling.spring.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,7 +25,11 @@ public class UserDetailService implements UserDetailsService {
 
     public UserDetails loadUserByUserId(Long id) throws UsernameNotFoundException {
 
-        return userRepository.findById(id).orElseThrow(
+        User user = userRepository.findById(id).orElseThrow(
                 () -> new UsernameNotFoundException("유저를 찾을 수 없습니다. userId: " + id));
+        if (user.getRefreshToken() == null)
+            throw new UsernameNotFoundException("로그아웃한 유저입니다. userId: " + id);
+
+        return user;
     }
 }

--- a/src/main/java/TImeCAlling/spring/web/controller/user/UserController.java
+++ b/src/main/java/TImeCAlling/spring/web/controller/user/UserController.java
@@ -59,14 +59,14 @@ public class UserController {
                                                                  @RequestPart(required = false) MultipartFile profileImage,
                                                                  @RequestPart UserRequestDTO.UserUpdateDTO userUpdateDTO) {
         
-        return ApiResponse.onSuccess(userCommandService.updateUser(user.getId(), profileImage, userUpdateDTO));
+        return ApiResponse.onSuccess(userCommandService.updateUser(user, profileImage, userUpdateDTO));
     }
     
     @GetMapping()
     @Operation(summary = "회원 조회", description = "로그인한 회원의 정보를 조회합니다.")
     public ApiResponse<UserResponseDTO.UserMyPageDTO> getUserMyPage(@AuthenticationPrincipal User user) {
         
-        return ApiResponse.onSuccess(userCommandService.findMyUsers(user.getId()));
+        return ApiResponse.onSuccess(UserConverter.toUserMyPageDTO(user));
     }
 
     @PostMapping("/token/refresh")

--- a/src/main/java/TImeCAlling/spring/web/controller/user/UserController.java
+++ b/src/main/java/TImeCAlling/spring/web/controller/user/UserController.java
@@ -1,6 +1,7 @@
 package TImeCAlling.spring.web.controller.user;
 
 import TImeCAlling.spring.apiPayload.ApiResponse;
+import TImeCAlling.spring.converter.user.UserConverter;
 import TImeCAlling.spring.domain.User;
 import TImeCAlling.spring.service.user.UserCommandService;
 import TImeCAlling.spring.web.dto.user.UserRequestDTO;
@@ -37,10 +38,12 @@ public class UserController {
         return ApiResponse.onSuccess(response);
     }
 
-    @PostMapping
-    @Operation(summary = "로그아웃")
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "로그아웃할 유저의 accessToken을 헤더로 넘겨주세요.")
     public ApiResponse<UserResponseDTO.UserIdDTO> logout(@AuthenticationPrincipal User user) {
-        return null;
+
+        User loggedOutUser = userCommandService.logout(user);
+        return ApiResponse.onSuccess(UserConverter.toUserIdDTO(loggedOutUser));
     }
     
     @DeleteMapping()

--- a/src/main/java/TImeCAlling/spring/web/controller/user/UserController.java
+++ b/src/main/java/TImeCAlling/spring/web/controller/user/UserController.java
@@ -20,18 +20,32 @@ public class UserController {
     
     private final UserCommandService userCommandService;
 
-    @PostMapping(value = "/test", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "(테스트용) 회원 생성", description = "회원 정보를 입력하여 새 회원을 생성합니다.")
-    public ApiResponse<UserResponseDTO.UserSignUpResultDTO> createUser(@RequestPart MultipartFile profileImage,
-                                                                       @RequestPart @Valid UserRequestDTO.UserCreateDTO request) {
+    @PostMapping(value = "/kakao/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "카카오 회원가입", description = "카카오 엑세스 토큰과 가입할 회원의 정보를 입력하세요.")
+    public ApiResponse<UserResponseDTO.UserSignUpResultDTO> kakaoSignUp (@RequestPart MultipartFile profileImage,
+                                                                         @RequestPart @Valid UserRequestDTO.UserSignUpDTO request) {
 
-        UserResponseDTO.UserSignUpResultDTO response = userCommandService.createUser(profileImage, request);
+        UserResponseDTO.UserSignUpResultDTO response = userCommandService.kakaoSignUp(profileImage, request);
         return ApiResponse.onSuccess(response);
+    }
+
+    @PostMapping("/kakao/login")
+    @Operation(summary = "카카오 로그인", description = "카카오 액세스 토큰을 입력하세요.")
+    public ApiResponse<UserResponseDTO.UserSignUpResultDTO> kakaoLogin (@RequestBody @Valid UserRequestDTO.UserLoginDTO request) {
+
+        UserResponseDTO.UserSignUpResultDTO response = userCommandService.kakaoLogin(request);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @PostMapping
+    @Operation(summary = "로그아웃")
+    public ApiResponse<UserResponseDTO.UserIdDTO> logout(@AuthenticationPrincipal User user) {
+        return null;
     }
     
     @DeleteMapping()
     @Operation(summary = "회원 탈퇴")
-    public ApiResponse<UserResponseDTO.UserDeleteDTO> deleteUser(@AuthenticationPrincipal User user) {
+    public ApiResponse<UserResponseDTO.UserIdDTO> deleteUser(@AuthenticationPrincipal User user) {
 
         return ApiResponse.onSuccess(userCommandService.deleteUser(user.getId()));
     }
@@ -52,28 +66,20 @@ public class UserController {
         return ApiResponse.onSuccess(userCommandService.findMyUsers(user.getId()));
     }
 
-    @PostMapping(value = "/kakao/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "카카오 회원가입", description = "카카오 엑세스 토큰과 가입할 회원의 정보를 입력하세요.")
-    public ApiResponse<UserResponseDTO.UserSignUpResultDTO> kakaoSignUp (@RequestPart MultipartFile profileImage,
-                                                                         @RequestPart @Valid UserRequestDTO.UserSignUpDTO request) {
-
-        UserResponseDTO.UserSignUpResultDTO response = userCommandService.kakaoSignUp(profileImage, request);
-        return ApiResponse.onSuccess(response);
-    }
-
-    @PostMapping("/kakao/login")
-    @Operation(summary = "카카오 로그인", description = "카카오 액세스 토큰을 입력하세요.")
-    public ApiResponse<UserResponseDTO.UserSignUpResultDTO> kakaoLogin (@RequestBody @Valid UserRequestDTO.UserLoginDTO request) {
-
-        UserResponseDTO.UserSignUpResultDTO response = userCommandService.kakaoLogin(request);
-        return ApiResponse.onSuccess(response);
-    }
-
     @PostMapping("/token/refresh")
     @Operation(summary = "액세스 토큰 재발급", description = "만료된 accessToken과 해당 회원의 refreshToken을 입력하세요.")
     public ApiResponse<UserResponseDTO.RefreshTokenResultDTO> refreshToken(@RequestBody UserRequestDTO.RefreshTokenDTO request) {
 
         UserResponseDTO.RefreshTokenResultDTO response = userCommandService.refreshToken(request);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @PostMapping(value = "/test", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "(테스트용) 회원 생성", description = "회원 정보를 입력하여 새 회원을 생성합니다.")
+    public ApiResponse<UserResponseDTO.UserSignUpResultDTO> createUser(@RequestPart MultipartFile profileImage,
+                                                                       @RequestPart @Valid UserRequestDTO.UserCreateDTO request) {
+
+        UserResponseDTO.UserSignUpResultDTO response = userCommandService.createUser(profileImage, request);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/TImeCAlling/spring/web/controller/user/UserController.java
+++ b/src/main/java/TImeCAlling/spring/web/controller/user/UserController.java
@@ -39,7 +39,7 @@ public class UserController {
     }
 
     @PostMapping("/logout")
-    @Operation(summary = "로그아웃", description = "로그아웃할 유저의 accessToken을 헤더로 넘겨주세요.")
+    @Operation(summary = "로그아웃", description = "헤더에 로그아웃할 유저의 accessToken을 입력하세요.")
     public ApiResponse<UserResponseDTO.UserIdDTO> logout(@AuthenticationPrincipal User user) {
 
         User loggedOutUser = userCommandService.logout(user);
@@ -50,7 +50,7 @@ public class UserController {
     @Operation(summary = "회원 탈퇴")
     public ApiResponse<UserResponseDTO.UserIdDTO> deleteUser(@AuthenticationPrincipal User user) {
 
-        return ApiResponse.onSuccess(userCommandService.deleteUser(user.getId()));
+        return ApiResponse.onSuccess(userCommandService.deleteUser(user));
     }
     
     @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/TImeCAlling/spring/web/dto/user/UserResponseDTO.java
+++ b/src/main/java/TImeCAlling/spring/web/dto/user/UserResponseDTO.java
@@ -8,20 +8,11 @@ public class UserResponseDTO {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor
     @Getter
-    public static class UserCreateDTO{
+    public static class UserIdDTO {
 
         Long userId;
     }
-    
-    @Builder
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    @AllArgsConstructor
-    @Getter
-    public static class UserDeleteDTO {
-        
-        Long userId;
-    }
-    
+
     @Builder
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,8 @@ spring:
         default_batch_fetch_size: 1000
   jwt:
     secret: ${JWT_SECRET}
+  kakao:
+    admin-key: ${ADMIN_KEY}
 
   cloud:
     aws:


### PR DESCRIPTION
## Issue
- #79

## Summary
1. 스웨거에서 리프레시 토큰을 입력할 수 있는 헤더 부분을 삭제하고, 액세스 토큰만을 입력할 수 있도록 수정했습니다.
2. 내용이 같은 UserCreateDTO, UserDeleteDTO를 UserIdDTO로 통합하였습니다.
3. 로그아웃 api를 새로 구현하고, 회원 탈퇴 시 카카오계정과 연결 끊기 기능을 추가하여 재로그인이 불가능하도록 에러를 수정했습니다.
- 로그아웃한 유저는 로그인 이외의 API를 요청할 수 없도록 예외처리 하였습니다. 재로그인하면 회원가입 절차 없이 기존 정보로 로그인됩니다.
    <img width="463" alt="스크린샷 2025-02-07 오후 2 27 28" src="https://github.com/user-attachments/assets/5a298194-11e8-46b9-ac1f-15251d4f8e89" />
- 회원 탈퇴한 유저는 재로그인이 불가능하고, 다시 회원가입 절차를 진행해야합니다.

## Describe your code
- 프론트와 회원가입 절차가 달라 임시로 만든 앱으로 테스트를 진행하였습니다!
1. 스웨거를 통해 카카오 회원가입 진행 
  -> 아래 url에 접속하고 정보 동의 후, 리다이렉트된 url에서 얻은 code로 kakaoAccessToken 발급받기
   <img width="633" alt="스크린샷 2025-02-07 오후 4 22 39" src="https://github.com/user-attachments/assets/365292fd-5e2f-4c89-a0fd-93d03618d070" />
2. kakaoAccessToken으로 카카오 회원가입 -> 발급된 accessToken을 헤더에 입력
    <img width="806" alt="스크린샷 2025-02-07 오후 4 43 20" src="https://github.com/user-attachments/assets/841e6c2c-b312-4c3d-9b95-520cd3e5bb86" />

3. 회원 탈퇴 후 재로그인 시도, 에러 확인
    <img width="450" alt="스크린샷 2025-02-07 오후 4 28 42" src="https://github.com/user-attachments/assets/88f60f07-fd53-4432-9b8b-01845724546f" />
 - 탈퇴 후 1번 과정을 진행하면 다시 처음부터 회원가입해야함을 확인할 수 있습니다!
    <img width="333" alt="스크린샷 2025-02-07 오후 4 34 26" src="https://github.com/user-attachments/assets/3f0735c2-8efe-44dd-8379-07ea73e8319b" />

테스트 방법이 복잡해서 큰 흐름을 정리해두었습니다! 궁금한 점이나 이상있는 부분이 있다면 리뷰 남겨주시면 감사하겠습니다🙇

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
