### PR TITLE
[FIX] 공유 일정 조회 시 닉네임 반환

### DIFF
--- a/src/main/java/TImeCAlling/spring/converter/schedule/ScheduleConverter.java
+++ b/src/main/java/TImeCAlling/spring/converter/schedule/ScheduleConverter.java
@@ -95,7 +95,7 @@ public class ScheduleConverter {
                     .map(Enum::toString)
                     .toList();
             return ScheduleResponseDTO.GetShareScheduleDTO.builder()
-                    .nickname(user.getNickname())
+                    .nickname(schedule.getUser().getNickname())
                     .name(schedule.getName())
                     .meetDate(schedule.getChecklists().get(0).getDate())
                     .meetTime(schedule.getMeetTime())
@@ -109,7 +109,7 @@ public class ScheduleConverter {
                     .build();
         } else {
             return ScheduleResponseDTO.GetShareScheduleDTO.builder()
-                    .nickname(user.getNickname())
+                    .nickname(schedule.getUser().getNickname())
                     .name(schedule.getName())
                     .meetDate(schedule.getChecklists().get(0).getDate())
                     .meetTime(schedule.getMeetTime())

--- a/src/main/java/TImeCAlling/spring/converter/schedule/ScheduleConverter.java
+++ b/src/main/java/TImeCAlling/spring/converter/schedule/ScheduleConverter.java
@@ -88,40 +88,27 @@ public class ScheduleConverter {
                 .build();
     }
 
-    public static ScheduleResponseDTO.GetShareScheduleDTO toGetShareScheduleDTO(User user, Schedule schedule, RecurringSchedule recurringSchedule) {
+    public static ScheduleResponseDTO.GetShareScheduleDTO toGetShareScheduleDTO(Schedule schedule, RecurringSchedule recurringSchedule) {
 
-        if (schedule.getIsRepeat()) {
-            List<String> repeatDays = recurringSchedule.getRepeatDays().stream()
-                    .map(Enum::toString)
-                    .toList();
-            return ScheduleResponseDTO.GetShareScheduleDTO.builder()
-                    .nickname(schedule.getUser().getNickname())
-                    .name(schedule.getName())
-                    .meetDate(schedule.getChecklists().get(0).getDate())
-                    .meetTime(schedule.getMeetTime())
-                    .place(schedule.getPlace())
-                    .longitude(schedule.getLongitude())
-                    .latitude(schedule.getLatitude())
-                    .repeatDays(repeatDays)
-                    .isRepeat(schedule.getIsRepeat())
-                    .start(recurringSchedule.getStart())
-                    .end(recurringSchedule.getEnd())
-                    .build();
-        } else {
-            return ScheduleResponseDTO.GetShareScheduleDTO.builder()
-                    .nickname(schedule.getUser().getNickname())
-                    .name(schedule.getName())
-                    .meetDate(schedule.getChecklists().get(0).getDate())
-                    .meetTime(schedule.getMeetTime())
-                    .place(schedule.getPlace())
-                    .longitude(schedule.getLongitude())
-                    .latitude(schedule.getLatitude())
-                    .repeatDays(null)
-                    .isRepeat(schedule.getIsRepeat())
-                    .start(null)
-                    .end(null)
-                    .build();
-        }
+        List<String> repeatDays = schedule.getIsRepeat()
+                ? recurringSchedule.getRepeatDays().stream()
+                .map(Enum::toString)
+                .toList()
+                : null;
+
+        return ScheduleResponseDTO.GetShareScheduleDTO.builder()
+                .nickname(schedule.getUser().getNickname())
+                .name(schedule.getName())
+                .meetDate(schedule.getChecklists().get(0).getDate())
+                .meetTime(schedule.getMeetTime())
+                .place(schedule.getPlace())
+                .longitude(schedule.getLongitude())
+                .latitude(schedule.getLatitude())
+                .repeatDays(repeatDays)
+                .isRepeat(schedule.getIsRepeat())
+                .start(schedule.getIsRepeat() ? recurringSchedule.getStart() : null)
+                .end(schedule.getIsRepeat() ? recurringSchedule.getEnd() : null)
+                .build();
     }
 
     public static Schedule toShareSchedule(User user, ScheduleRequestDTO.ScheduleCommandDTO request, String shareId){

--- a/src/main/java/TImeCAlling/spring/web/controller/schedule/ScheduleController.java
+++ b/src/main/java/TImeCAlling/spring/web/controller/schedule/ScheduleController.java
@@ -86,7 +86,7 @@ public class ScheduleController {
     public ApiResponse<ScheduleResponseDTO.GetShareScheduleDTO> getShareSchedule(@AuthenticationPrincipal User user, @PathVariable @ExistSchedule Long scheduleId) {
 
         Schedule schedule = scheduleQueryService.getShareSchedule(scheduleId, user);
-        return ApiResponse.onSuccess(ScheduleConverter.toGetShareScheduleDTO(user, schedule, schedule.getRecurringSchedule()));
+        return ApiResponse.onSuccess(ScheduleConverter.toGetShareScheduleDTO(schedule, schedule.getRecurringSchedule()));
     }
 
     @Operation(summary = "공유 일정 추가", description = "공유 일정을 추가합니다. meetTime에 HH:mm 형식만 입력 가능합니다!")


### PR DESCRIPTION
## Issue

- #85 

## Summary

- GET /api/schedules/share/{scheduleId} 요청 시 해당 일정의 유저 닉네임 반환

## Describe your code

- 닉네임 반환 코드 수정
- 리팩토링, 중복 코드 삭제

# Check
- [ ] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
