### PR TITLE
[FEATURE&REFACTOR] 깨우기 API에서 다양한 멘트를 위한 코드 추가 및 수정

### DIFF
--- a/src/main/java/TImeCAlling/spring/service/pushMessageNotification/PushDefaultMessage.java
+++ b/src/main/java/TImeCAlling/spring/service/pushMessageNotification/PushDefaultMessage.java
@@ -1,0 +1,38 @@
+package TImeCAlling.spring.service.pushMessageNotification;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * FCM 기본 알림 메세지 Enum
+ */
+@Getter
+@RequiredArgsConstructor
+public enum PushDefaultMessage {
+    PUSH_DEFAULT_MESSAGE0(0, "푸시 테스트 메세지 0"),
+    PUSH_DEFAULT_MESSAGE1(1, "푸시 테스트 메세지 1"),
+    PUSH_DEFAULT_MESSAGE2(2, "푸시 테스트 메세지 2"),
+    PUSH_DEFAULT_MESSAGE3(3, "푸시 테스트 메세지 3"),
+    PUSH_DEFAULT_MESSAGE4(4, "푸시 테스트 메세지 4"),
+    PUSH_DEFAULT_MESSAGE5(5, "푸시 테스트 메세지 5"),
+    PUSH_DEFAULT_MESSAGE6(6, "푸시 테스트 메세지 6");
+
+    private final int idx;
+    private final String body;
+
+    private static final Map<Integer, String> INDEX_MAP = new HashMap<>();
+
+    static {
+        for (PushDefaultMessage message : values()) {
+            INDEX_MAP.put(message.idx, message.body);
+        }
+    }
+
+    public static Optional<String> fromIndex(int index) {
+        return Optional.ofNullable(PushDefaultMessage.INDEX_MAP.get(index));
+    }
+}

--- a/src/main/java/TImeCAlling/spring/service/pushMessageNotification/PushNotificationCommandServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/pushMessageNotification/PushNotificationCommandServiceImpl.java
@@ -31,7 +31,10 @@ import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Service
 @Transactional
@@ -129,16 +132,26 @@ public class PushNotificationCommandServiceImpl implements PushNotificationComma
 
         ObjectMapper objectMapper = new ObjectMapper();
 
-        String body = String.format("%s님이 %s라고 하셨어!", user.getNickname(), notificationDTO.getBody());
+        int randomIndex = ThreadLocalRandom.current().nextInt(0, PushDefaultMessage.values().length);
+        String defaultMessage = PushDefaultMessage.fromIndex(randomIndex)
+                .orElse(PushDefaultMessage.PUSH_DEFAULT_MESSAGE0.getBody());
 
+        Map<String, String> data = new HashMap<>();
+        data.put("title", schedule.getName());
+        data.put("body", defaultMessage);
+        data.put("scheduledDate", notificationDTO.getScheduledDate());
+        data.put("senderNickname", user.getNickname());
+
+        /*body 부분 notificationDTO.getBody() -> defaultMessage 랜덤 메세지로 수정*/
         FcmMessageDTO fcmMessageDTO = FcmMessageDTO.builder()
                 .message(FcmMessageDTO.Message.builder()
                         .token(receiverFcmToken)
-                        .notification(FcmMessageDTO.Notification.builder()
-                                .title(schedule.getName())
-                                .body(body)
-                                .build()
-                        ).build()).validateOnly(false).build();
+                        .data(data)
+                        .android(FcmMessageDTO.AndroidConfig.builder()
+                                .ttl("0s")
+                                .priority("high")
+                                .build())
+                        .build()).validateOnly(false).build();
 
         return objectMapper.writeValueAsString(fcmMessageDTO);
     }

--- a/src/main/java/TImeCAlling/spring/web/controller/pushMessageNotification/PushMessageNotificationController.java
+++ b/src/main/java/TImeCAlling/spring/web/controller/pushMessageNotification/PushMessageNotificationController.java
@@ -53,8 +53,8 @@ public class PushMessageNotificationController {
      */
     @Operation(
             summary = "같은 일정을 공유하는 팀원에게 FCM 알람이 가도록합니다.",
-            description = "수신자의 id와 공유하고 싶은 스케줄은 'shareId'를 통해 보내주세요. body 같은 내용 추가 부분도" +
-            "확장성을 고려하여 미리 추가하였습니다. 없으시면 기본 메세지로 json을 날려주세요!"
+            description = "수신자의 id와 공유하고 싶은 스케줄은 'shareId'를 통해 보내주세요. body 부분은 랜덤 기본 메세지로" +
+            "수정되었습니다 추가적으로, 스케줄 날짜를 scheduledDate로 보내주세요(2025-02-12)!"
     )
     @PostMapping()
     public ApiResponse<PushNotificationResponseDTO.NotificationDetails> userWakeUp(

--- a/src/main/java/TImeCAlling/spring/web/dto/fcm/FcmMessageDTO.java
+++ b/src/main/java/TImeCAlling/spring/web/dto/fcm/FcmMessageDTO.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Map;
+
 /**
  * FCM 전송 Format DTO
  *
@@ -18,15 +20,25 @@ public class FcmMessageDTO {
     @AllArgsConstructor
     @Getter
     public static class Message {
-        private FcmMessageDTO.Notification notification;
+//        private FcmMessageDTO.Notification notification;
         private String token;
+        private Map<String, String> data;
+        private FcmMessageDTO.AndroidConfig android;
     }
+
+//    @Builder
+//    @AllArgsConstructor
+//    @Getter
+//    public static class Notification {
+//        private String title;
+//        private String body;
+//    }
 
     @Builder
     @AllArgsConstructor
     @Getter
-    public static class Notification {
-        private String title;
-        private String body;
+    public static class AndroidConfig {
+        private String ttl; //Time-to-Live ("3600" -> 1시간)
+        private String priority; // 우선순위 설정 -> 타임콜링은 시간이 중요하므로 high 설정 권장
     }
 }

--- a/src/main/java/TImeCAlling/spring/web/dto/pushMessageNotification/PushNotificationRequestDTO.java
+++ b/src/main/java/TImeCAlling/spring/web/dto/pushMessageNotification/PushNotificationRequestDTO.java
@@ -8,6 +8,6 @@ public class PushNotificationRequestDTO {
     public static class NotificationDetails {
         private Long receiverId;
         private String shareId;
-        private String body;
+        private String scheduledDate;
     }
 }


### PR DESCRIPTION
## Issue

- #84 


## Summary

- 사용자 지정 메세지에서 랜덤 기본 메시지가 발송되도록 수정하였습니다.
- 랜덤 기본 메시지를 위한 PushDefaultMessage ENUM 클래스를 추가하였습니다.
- 프론트 분의 니즈에 맞게 Request body를 변경했고, 이에 따른 swagger 수정 및 DTO 수정을 하였습니다.

## Describe your code

![image](https://github.com/user-attachments/assets/fa63e08f-18a9-4b2d-a235-6cb5ba3dc16d)

- 해당 부분은 차후 PM님이 주신 멘트로 수정 예정입니다!

![3](https://github.com/user-attachments/assets/6631b74c-f6ed-4f4f-a108-82b42ee6690b)

- 연속적으로 깨우기 API 시도 시에, 다른 메시지가 날라옴을 확인하였습니다.

![2](https://github.com/user-attachments/assets/5b1a7ac1-37e1-4f22-a851-41e45cd1c38b)
![타임콜링 깨우기](https://github.com/user-attachments/assets/f8cc780d-ab94-4a15-ba92-95cc92c52bc1)

- 해당 API에서 원하는 정보를 얻을 수 있게 DTO를 수정했고, 테스트 용 앱에서 정상 작동됨을 확인하였습니다!


⭐ 백엔드 팀원분들이 테스트 해보시기 위해선, API 연결 후 해당 앱이 설치된 가상머신 (혹은 실제 폰) + firebase_service_key가 필요합니다 😢
API 연결이 끝난 후, 실제 테스트를 로컬에서 돌리기 위해 firebase_service_key 를 팀원 카톡방에 배포할 예정입니다!!

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
