### PR TITLE
[FEATURE] Hibernate 2차 캐시 도입 & 일정 엔티티 조회 성능 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,12 @@ dependencies {
 
 	// Google Auth Library
 	implementation 'com.google.auth:google-auth-library-oauth2-http:1.16.0'
+
+	// JCache & Ehcache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'org.hibernate:hibernate-jcache:6.0.2.Final'
+	implementation 'org.ehcache:ehcache:3.10.0'
+	implementation 'javax.cache:cache-api:1.1.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/TImeCAlling/spring/config/CacheConfig.java
+++ b/src/main/java/TImeCAlling/spring/config/CacheConfig.java
@@ -1,0 +1,39 @@
+package TImeCAlling.spring.config;
+
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+    @Bean(name = "customCacheManager")
+    public CacheManager customCacheManager() {
+        org.ehcache.config.CacheConfiguration<Object, Object> ehcacheConfig =
+                CacheConfigurationBuilder.newCacheConfigurationBuilder(
+                                Object.class,
+                                Object.class,
+                                ResourcePoolsBuilder.heap(100)
+                        )
+                        .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.ofSeconds(3600)))
+                        .build();
+
+        javax.cache.configuration.Configuration<Object, Object> jcacheConfig =
+                Eh107Configuration.fromEhcacheCacheConfiguration(ehcacheConfig);
+
+        javax.cache.spi.CachingProvider cachingProvider = Caching.getCachingProvider();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+
+        cacheManager.createCache("hibernateCache", jcacheConfig);
+
+        return cacheManager;
+    }
+}

--- a/src/main/java/TImeCAlling/spring/domain/Schedule.java
+++ b/src/main/java/TImeCAlling/spring/domain/Schedule.java
@@ -5,6 +5,8 @@ import TImeCAlling.spring.domain.enums.*;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,6 +16,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Entity
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "hibernateCache")
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,15 @@ spring:
         format_sql: true
         use_sql_comments: true
         default_batch_fetch_size: 1000
+        generate_statistics: true
+        cache:
+          use_second_level_cache: true
+          factory_class: org.hibernate.cache.jcache.internal.JCacheRegionFactory
+      javax:
+        persistence:
+          sharedCache:
+          mode: ENABLE_SELECTIVE
+
   jwt:
     secret: ${JWT_SECRET}
   kakao:


### PR DESCRIPTION
## Issue
- #90 

## Summary
- JCache 타입의 Hibernate 2차 캐시를 도입하였습니다.
- Schedule 엔티티에 대하여 2차 캐싱을 적용시켰습니다.

## Describe your code

- 처음 조회 시
<img width="822" alt="스크린샷 2025-02-12 오후 10 47 46" src="https://github.com/user-attachments/assets/9880f23e-2549-49d0-acc9-f85df47ab536" />

- 이후 조회 시
<img width="830" alt="스크린샷 2025-02-12 오후 10 47 54" src="https://github.com/user-attachments/assets/a4827328-8be0-47f3-90c0-fbf06811001c" />

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
