### PR TITLE
[HOTFIX] Schedule이 의도치않게 여러 개가 되는 오류 수정

### DIFF
--- a/src/main/java/TImeCAlling/spring/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/TImeCAlling/spring/repository/schedule/ScheduleRepository.java
@@ -29,5 +29,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     Integer countByShareId(String shareId);
 
-    Optional<Schedule> findByShareIdAndUser(String shareId, User user);
+    @Query("SELECT s FROM Schedule s WHERE s.shareId = :shareId AND s.user = :user")
+    Optional<Schedule> findFirstByShareIdAndUser(@Param("shareId") String shareId, @Param("user") User user);
 }

--- a/src/main/java/TImeCAlling/spring/service/pushMessageNotification/PushNotificationCommandServiceImpl.java
+++ b/src/main/java/TImeCAlling/spring/service/pushMessageNotification/PushNotificationCommandServiceImpl.java
@@ -68,7 +68,7 @@ public class PushNotificationCommandServiceImpl implements PushNotificationComma
         String receiverFcmToken = userRepository.findFcmTokenByUserId(notificationDTO.getReceiverId())
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        Schedule schedule = scheduleRepository.findByShareIdAndUser(notificationDTO.getShareId(), user)
+        Schedule schedule = scheduleRepository.findFirstByShareIdAndUser(notificationDTO.getShareId(), user)
                 .orElseThrow(() -> new ScheduleHandler(ErrorStatus.SCHEDULE_NOT_FOUND));
 
         String message = makeMessage(receiverFcmToken, schedule, notificationDTO, user);
@@ -140,10 +140,10 @@ public class PushNotificationCommandServiceImpl implements PushNotificationComma
                 .orElse(PushDefaultMessage.PUSH_DEFAULT_MESSAGE0.getBody());
 
         Map<String, String> data = new HashMap<>();
-        data.put("title", schedule.getName());
+        data.put("title", schedule.getName() != null ? schedule.getName() : "스케줄 제목 없음");
         data.put("body", defaultMessage);
-        data.put("scheduledDate", notificationDTO.getScheduledDate());
-        data.put("senderNickname", user.getNickname());
+        data.put("scheduledDate", notificationDTO.getScheduledDate() != null ? notificationDTO.getScheduledDate() : "N/A");
+        data.put("senderNickname", user.getNickname() != null ? user.getNickname() : "기본 이름");
 
         /*body 부분 notificationDTO.getBody() -> defaultMessage 랜덤 메세지로 수정*/
         FcmMessageDTO fcmMessageDTO = FcmMessageDTO.builder()


### PR DESCRIPTION
## Issue

- 이슈 없음


## Summary

```
 <-- 500 https://timecalling.shop/api/push-requests (129ms)
{"isSuccess":false,"code":"COMMON500","message":"서버 에러, 관리자에게 문의 바랍니다.","result":"Query did not return a unique result: 5 results were returned"}
```

프런트에서 해당 오류 발생 : "Query did not return a unique result: 5 results were returned"
-> 하나의 스케줄만 와야 하는데 여러 개가 조회 되었을 때, 생기는 오류 수정


## Describe your code

- LIMIT 1 추가로 한개만 반환하도록 설정

# Check
- [ ] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
